### PR TITLE
Fix static build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .ONESHELL:
 .SECONDEXPANSION:
 .DELETE_ON_ERROR:
+.EXPORT_ALL_VARIABLES
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
@@ -21,6 +22,7 @@ GITHUB_REF ?= dev
 GIT_REF ?= $(subst refs/heads/,,$(subst refs/tags/,,$(GITHUB_REF)))
 GITHUB_SHA ?= dev
 GIT_SHA ?= $(GITHUB_SHA)
+
 CGO_ENABLED ?= 0
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .ONESHELL:
 .SECONDEXPANSION:
 .DELETE_ON_ERROR:
-.EXPORT_ALL_VARIABLES
+.EXPORT_ALL_VARIABLES:
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 .DEFAULT_GOAL :=help
 
 GITHUB_REF ?= dev
-GIT_REF ?= $(subst refs/heads/,,$(subst refs/tags/,,$(GITHUB_REF)))
+GIT_REF ?= $(shell echo "$(GITHUB_REF)" | sed "s,refs/[^/]*/,," | tr -cd '[:alnum:]._')
 GITHUB_SHA ?= dev
 GIT_SHA ?= $(GITHUB_SHA)
 

--- a/scripts/alpine-setup.sh
+++ b/scripts/alpine-setup.sh
@@ -7,6 +7,7 @@ LC_CTYPE=C
 UPX_VERSION="3.96"
 
 apk add --update --no-cache \
+	git \
 	make \
 	tar
 


### PR DESCRIPTION
This fixes build to produce static binaries - the `CGO_ENABLE` did not get propagated in the GH action build container.

Fixes #1 