### PR TITLE
(ref) Move logic to unpack last-applied config to collector

### DIFF
--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -1,6 +1,8 @@
 package collector
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -51,8 +53,17 @@ func (c *ClusterCollector) Get() ([]interface{}, error) {
 			return nil, err
 		}
 
+		var resource interface{}
+
 		for _, r := range rs.Items {
-			results = append(results, r.Object)
+			if jsonManifest, ok := r.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]; ok {
+
+				err := json.Unmarshal([]byte(jsonManifest), &resource)
+				if err != nil {
+					return nil, err
+				}
+				results = append(results, resource)
+			}
 		}
 	}
 

--- a/rules/deprecated-1-16.rego
+++ b/rules/deprecated-1-16.rego
@@ -11,11 +11,6 @@ main[return] {
 }
 
 deprecated_resource(r) = old_api {
-  last_applied := json.unmarshal(r.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])
-  old_api := deprecated_api(r.kind, last_applied.apiVersion)
-}
-
-deprecated_resource(r) = old_api {
   old_api := deprecated_api(r.kind, r.apiVersion)
 }
 

--- a/rules/deprecated-1-20.rego
+++ b/rules/deprecated-1-20.rego
@@ -11,11 +11,6 @@ main[return] {
 }
 
 deprecated_resource(r) = old_api {
-  last_applied := json.unmarshal(r.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])
-  old_api := deprecated_api(r.kind, last_applied.apiVersion)
-}
-
-deprecated_resource(r) = old_api {
   old_api := deprecated_api(r.kind, r.apiVersion)
 }
 


### PR DESCRIPTION
This PR moves logic to unpack manifest from `kubectl.kubernetes.io/last-applied-configuration`, in case of Cluster collector, from OPA rules to collector itself. This unifies handling for all collectors.

This also fixes bug when resources from Cluster collector might be flagged as deprecated, even if they were created with a non-deprecated API version.