### PR TITLE
Support resources without Namespace + fmt checks

### DIFF
--- a/rules/deprecated-1-16.rego
+++ b/rules/deprecated-1-16.rego
@@ -1,37 +1,43 @@
 package deprecated116
 
 main[return] {
-  resource := input[_]
-  old_api := deprecated_resource(resource)
-  return := {"Name": resource.metadata.name,
-             # Namespace does not have to be defined in case of local manifests
-             "Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
-	         "Kind": resource.kind,
-	         "ApiVersion": old_api,
-	         "RuleSet": "1.16 Deprecated APIs"}
+	resource := input[_]
+	old_api := deprecated_resource(resource)
+	return := {
+		"Name": resource.metadata.name,
+		# Namespace does not have to be defined in case of local manifests
+		"Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
+		"Kind": resource.kind,
+		"ApiVersion": old_api,
+		"RuleSet": "1.16 Deprecated APIs",
+	}
 }
 
 deprecated_resource(r) = old_api {
-  old_api := deprecated_api(r.kind, r.apiVersion)
+	old_api := deprecated_api(r.kind, r.apiVersion)
 }
 
 deprecated_api(kind, api_version) = old_api {
-  deprecated_apis = { # -> apps/v1
-                      "Deployment":        ["extensions/v1beta1", "apps/v1beta1", "apps/v1beta2"],
-                      # -> networking.k8s.io/v1
-                      "NetworkPolicy":     ["extensions/v1beta1"],
-                      # -> policy/v1beta1
-                      "PodSecurityPolicy": ["extensions/v1beta1"],
-                      # -> apps/v1
-                      "DaemonSet":         ["extensions/v1beta1", "apps/v1beta2"],
-                      # -> apps/v1
-                      "StatefulSet":       ["apps/v1beta1", "apps/v1beta2"],
-                      # -> apps/v1
-                      "ReplicaSet":        ["extensions/v1beta1", "apps/v1beta1", "apps/v1beta2"]
-                    }
-  deprecated_apis[kind][_] == api_version
-  old_api := api_version
+	deprecated_apis = {
+		"Deployment": ["extensions/v1beta1", "apps/v1beta1", "apps/v1beta2"], # -> apps/v1
+		# -> networking.k8s.io/v1
+		"NetworkPolicy": ["extensions/v1beta1"],
+		# -> policy/v1beta1
+		"PodSecurityPolicy": ["extensions/v1beta1"],
+		# -> apps/v1
+		"DaemonSet": ["extensions/v1beta1", "apps/v1beta2"],
+		# -> apps/v1
+		"StatefulSet": ["apps/v1beta1", "apps/v1beta2"],
+		# -> apps/v1
+		"ReplicaSet": ["extensions/v1beta1", "apps/v1beta1", "apps/v1beta2"],
+	}
+
+	deprecated_apis[kind][_] == api_version
+	old_api := api_version
 }
 
 get_default(val, key, _) = val[key]
-get_default(val, key, fallback) = fallback { not val[key] }
+
+get_default(val, key, fallback) = fallback {
+	not val[key]
+}

--- a/rules/deprecated-1-16.rego
+++ b/rules/deprecated-1-16.rego
@@ -3,11 +3,12 @@ package deprecated116
 main[return] {
   resource := input[_]
   old_api := deprecated_resource(resource)
-  return := {"Name": resource.metadata.name, 
-             "Namespace": resource.metadata.namespace,
-	     "Kind": resource.kind,
-	     "ApiVersion": old_api,
-	     "RuleSet": "1.16 Deprecated APIs"}
+  return := {"Name": resource.metadata.name,
+             # Namespace does not have to be defined in case of local manifests
+             "Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
+	         "Kind": resource.kind,
+	         "ApiVersion": old_api,
+	         "RuleSet": "1.16 Deprecated APIs"}
 }
 
 deprecated_resource(r) = old_api {
@@ -31,3 +32,6 @@ deprecated_api(kind, api_version) = old_api {
   deprecated_apis[kind][_] == api_version
   old_api := api_version
 }
+
+get_default(val, key, _) = val[key]
+get_default(val, key, fallback) = fallback { not val[key] }

--- a/rules/deprecated-1-20.rego
+++ b/rules/deprecated-1-20.rego
@@ -4,10 +4,11 @@ main[return] {
   resource := input[_]
   old_api := deprecated_resource(resource)
   return := {"Name": resource.metadata.name, 
-             "Namespace": resource.metadata.namespace,
-	     "Kind": resource.kind,
-	     "ApiVersion": old_api,
-	     "RuleSet": "1.20 Deprecated APIs"}
+             # Namespace does not have to be defined in case of local manifests
+             "Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
+	         "Kind": resource.kind,
+	         "ApiVersion": old_api,
+	         "RuleSet": "1.20 Deprecated APIs"}
 }
 
 deprecated_resource(r) = old_api {
@@ -21,3 +22,6 @@ deprecated_api(kind, api_version) = old_api {
   deprecated_apis[kind][_] == api_version
   old_api := api_version
 }
+
+get_default(val, key, _) = val[key]
+get_default(val, key, fallback) = fallback { not val[key] }

--- a/rules/deprecated-1-20.rego
+++ b/rules/deprecated-1-20.rego
@@ -1,27 +1,31 @@
 package deprecated120
 
 main[return] {
-  resource := input[_]
-  old_api := deprecated_resource(resource)
-  return := {"Name": resource.metadata.name, 
-             # Namespace does not have to be defined in case of local manifests
-             "Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
-	         "Kind": resource.kind,
-	         "ApiVersion": old_api,
-	         "RuleSet": "1.20 Deprecated APIs"}
+	resource := input[_]
+	old_api := deprecated_resource(resource)
+	return := {
+		"Name": resource.metadata.name,
+		# Namespace does not have to be defined in case of local manifests
+		"Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
+		"Kind": resource.kind,
+		"ApiVersion": old_api,
+		"RuleSet": "1.20 Deprecated APIs",
+	}
 }
 
 deprecated_resource(r) = old_api {
-  old_api := deprecated_api(r.kind, r.apiVersion)
+	old_api := deprecated_api(r.kind, r.apiVersion)
 }
 
 deprecated_api(kind, api_version) = old_api {
-  deprecated_apis = { # -> networking.k8s.io/v1beta1
-                      "Ingress":        ["extensions/v1beta1"],
-                    }
-  deprecated_apis[kind][_] == api_version
-  old_api := api_version
+	deprecated_apis = {"Ingress": ["extensions/v1beta1"]} # -> networking.k8s.io/v1beta1
+
+	deprecated_apis[kind][_] == api_version
+	old_api := api_version
 }
 
 get_default(val, key, _) = val[key]
-get_default(val, key, fallback) = fallback { not val[key] }
+
+get_default(val, key, fallback) = fallback {
+	not val[key]
+}

--- a/scripts/alpine-setup.sh
+++ b/scripts/alpine-setup.sh
@@ -5,6 +5,7 @@ set -emou pipefail
 LC_CTYPE=C
 
 UPX_VERSION="3.96"
+OPA_VERSION="0.22.0"
 
 apk add --update --no-cache \
 	git \
@@ -14,5 +15,8 @@ apk add --update --no-cache \
 
 wget -qO- "https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz" \
   | tar --strip 1 -xJv -C "/usr/local/bin/" "upx-${UPX_VERSION}-amd64_linux/upx"
+
+wget -q -O "/usr/local/bin/opa" "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_amd64"
+chmod +x "/usr/local/bin/opa"
 
 go get github.com/rakyll/statik


### PR DESCRIPTION
This PR introduces changes required to support local file collector - **Rego rules - support resources without namespace** - and also adds `opa fmt` and `go fmt` checks.