### PR TITLE
Add stdin support for File collector

### DIFF
--- a/pkg/collector/file.go
+++ b/pkg/collector/file.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/ghodss/yaml"
 	"helm.sh/helm/v3/pkg/releaseutil"
@@ -39,7 +40,13 @@ func (c *FileCollector) Get() ([]interface{}, error) {
 	var results []interface{}
 
 	for _, f := range c.filenames {
-		input, err := ioutil.ReadFile(f)
+		var input []byte
+		var err error
+		if f == "-" {
+			input, err = ioutil.ReadAll(os.Stdin)
+		} else {
+			input, err = ioutil.ReadFile(f)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file %s: %v", f, err)
 		}

--- a/pkg/collector/file_test.go
+++ b/pkg/collector/file_test.go
@@ -1,6 +1,8 @@
 package collector
 
 import (
+	"io"
+	"os"
 	"strings"
 	"testing"
 )
@@ -91,5 +93,51 @@ func TestFileCollectorGetNonExistent(t *testing.T) {
 		t.Errorf("Expected error with non-existent file type")
 	} else if !strings.Contains(err.Error(), expected) {
 		t.Errorf("Expected error message with %s, got %s", expected, err.Error())
+	}
+}
+
+func TestFileCollectorGetStdin(t *testing.T) {
+	input := []string{"-"}
+	inputFilename := "../../fixtures/deployment-v1beta1.yaml"
+	expected := 1
+
+	c, err := NewFileCollector(
+		&FileOpts{Filenames: input},
+	)
+	if err != nil {
+		t.Errorf("Expected to succeed for %s, failed: %s", input, err)
+	}
+
+	fakeStdinReader, fakeStdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Errorf("Failed to create pipe for Stdin redirect: %s", err)
+	}
+
+	// override os.stdin
+	origStdin := os.Stdin
+	os.Stdin = fakeStdinReader
+	defer func() {
+		os.Stdin = origStdin
+		fakeStdinReader.Close()
+	}()
+
+	f, err := os.Open(inputFilename)
+	if err != nil {
+		t.Errorf("Failed to open fixture file %s: %s", inputFilename, err)
+	}
+	defer func() { f.Close() }()
+
+	// read file to fake stdin
+	_, err = io.Copy(fakeStdinWriter, f)
+	if err != nil {
+		t.Errorf("Failed to read fixture file: %s", err)
+	}
+	fakeStdinWriter.Close()
+
+	manifests, err := c.Get()
+	if err != nil {
+		t.Errorf("Expected to succeed for %s, failed: %s", input, err)
+	} else if len(manifests) != expected {
+		t.Errorf("Expected to get %d, got %d", expected, len(manifests))
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ func NewFromFlags() (*Config, error) {
 	flag.BoolVarP(&config.Debug, "debug", "d", false, "enable debug logging")
 	flag.BoolVar(&config.Helm2, "helm2", true, "enable Helm v2 collector")
 	flag.BoolVar(&config.Helm3, "helm3", true, "enable Helm v3 collector")
-	flag.StringSliceVarP(&config.Filenames, "filename", "f", []string{}, "manifests to check")
+	flag.StringSliceVarP(&config.Filenames, "filename", "f", []string{}, "manifests to check, use - for stdin")
 	flag.StringVarP(&config.Kubeconfig, "kubeconfig", "k", filepath.Join(home, ".kube", "config"), "path to the kubeconfig file")
 	flag.StringVarP(&config.Output, "output", "o", "text", "output format - [text|json]")
 


### PR DESCRIPTION
This PR adds support for stdin input for File collector. Usage: `-f -`.

```
$ cat manifest.yaml | ./kubent -f-
```

Fixes #6 