### PR TITLE
Better error reporting

### DIFF
--- a/cmd/kubent/main.go
+++ b/cmd/kubent/main.go
@@ -21,8 +21,8 @@ var (
 	gitSha  string = "dev"
 )
 
-func getCollectors(collectors []collector.Collector) []interface{} {
-	var inputs []interface{}
+func getCollectors(collectors []collector.Collector) []map[string]interface{} {
+	var inputs []map[string]interface{}
 	for _, c := range collectors {
 		rs, err := c.Get()
 		if err != nil {

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"encoding/json"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -60,6 +61,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 
 				err := json.Unmarshal([]byte(jsonManifest), &manifest)
 				if err != nil {
+					err := fmt.Errorf("failed to parse 'last-applied-configuration' annotation of resource %s/%s: %v", r.GetNamespace(), r.GetName(), err)
 					return nil, err
 				}
 				results = append(results, manifest)

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -34,7 +34,7 @@ func NewClusterCollector(opts *ClusterOpts) (*ClusterCollector, error) {
 	return collector, nil
 }
 
-func (c *ClusterCollector) Get() ([]interface{}, error) {
+func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 	gvrs := []schema.GroupVersionResource{
 		schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"},
 		schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
@@ -45,7 +45,7 @@ func (c *ClusterCollector) Get() ([]interface{}, error) {
 		schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "ingresses"},
 	}
 
-	var results []interface{}
+	var results []map[string]interface{}
 	for _, g := range gvrs {
 		ri := c.clientset.Resource(g)
 		rs, err := ri.List(metav1.ListOptions{})
@@ -53,16 +53,16 @@ func (c *ClusterCollector) Get() ([]interface{}, error) {
 			return nil, err
 		}
 
-		var resource interface{}
+		var manifest map[string]interface{}
 
 		for _, r := range rs.Items {
 			if jsonManifest, ok := r.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]; ok {
 
-				err := json.Unmarshal([]byte(jsonManifest), &resource)
+				err := json.Unmarshal([]byte(jsonManifest), &manifest)
 				if err != nil {
 					return nil, err
 				}
-				results = append(results, resource)
+				results = append(results, manifest)
 			}
 		}
 	}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,7 +1,7 @@
 package collector
 
 type Collector interface {
-	Get() ([]interface{}, error)
+	Get() ([]map[string]interface{}, error)
 	Name() string
 }
 

--- a/pkg/collector/file.go
+++ b/pkg/collector/file.go
@@ -34,10 +34,10 @@ func NewFileCollector(opts *FileOpts) (*FileCollector, error) {
 	return collector, nil
 }
 
-func (c *FileCollector) Get() ([]interface{}, error) {
+func (c *FileCollector) Get() ([]map[string]interface{}, error) {
 
 	var manifest map[string]interface{}
-	var results []interface{}
+	var results []map[string]interface{}
 
 	for _, f := range c.filenames {
 		var input []byte

--- a/pkg/collector/helm2.go
+++ b/pkg/collector/helm2.go
@@ -44,7 +44,7 @@ func NewHelmV2Collector(opts *HelmV2Opts) (*HelmV2Collector, error) {
 	return collector, nil
 }
 
-func (c *HelmV2Collector) Get() ([]interface{}, error) {
+func (c *HelmV2Collector) Get() ([]map[string]interface{}, error) {
 
 	releases, err := c.secretsStore.ListDeployed()
 	if err != nil {
@@ -58,17 +58,17 @@ func (c *HelmV2Collector) Get() ([]interface{}, error) {
 
 	releases = append(releases, releasesConfig...)
 
-	var input interface{}
-	var results []interface{}
+	var manifest map[string]interface{}
+	var results []map[string]interface{}
 
 	for _, r := range releases {
 		manifests := releaseutil.SplitManifests(r.Manifest)
 		for _, m := range manifests {
-			err := yaml.Unmarshal([]byte(m), &input)
+			err := yaml.Unmarshal([]byte(m), &manifest)
 			if err != nil {
 				return nil, err
 			}
-			results = append(results, input)
+			results = append(results, manifest)
 		}
 	}
 

--- a/pkg/collector/helm2.go
+++ b/pkg/collector/helm2.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"fmt"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -66,6 +67,7 @@ func (c *HelmV2Collector) Get() ([]map[string]interface{}, error) {
 		for _, m := range manifests {
 			err := yaml.Unmarshal([]byte(m), &manifest)
 			if err != nil {
+				err := fmt.Errorf("failed to parse release %s/%s: %v", r.Namespace, r.Name, err)
 				return nil, err
 			}
 			results = append(results, manifest)

--- a/pkg/collector/helm3.go
+++ b/pkg/collector/helm3.go
@@ -44,7 +44,7 @@ func NewHelmV3Collector(opts *HelmV3Opts) (*HelmV3Collector, error) {
 	return collector, nil
 }
 
-func (c *HelmV3Collector) Get() ([]interface{}, error) {
+func (c *HelmV3Collector) Get() ([]map[string]interface{}, error) {
 
 	releases, err := c.secretsStore.ListDeployed()
 	if err != nil {
@@ -58,17 +58,17 @@ func (c *HelmV3Collector) Get() ([]interface{}, error) {
 
 	releases = append(releases, releasesConfig...)
 
-	var input interface{}
-	var results []interface{}
+	var manifest map[string]interface{}
+	var results []map[string]interface{}
 
 	for _, r := range releases {
 		manifests := releaseutil.SplitManifests(r.Manifest)
 		for _, m := range manifests {
-			err := yaml.Unmarshal([]byte(m), &input)
+			err := yaml.Unmarshal([]byte(m), &manifest)
 			if err != nil {
 				return nil, err
 			}
-			results = append(results, input)
+			results = append(results, manifest)
 		}
 	}
 

--- a/pkg/collector/helm3.go
+++ b/pkg/collector/helm3.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"fmt"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -66,6 +67,7 @@ func (c *HelmV3Collector) Get() ([]map[string]interface{}, error) {
 		for _, m := range manifests {
 			err := yaml.Unmarshal([]byte(m), &manifest)
 			if err != nil {
+				err := fmt.Errorf("failed to parse release %s/%s: %v", r.Namespace, r.Name, err)
 				return nil, err
 			}
 			results = append(results, manifest)

--- a/pkg/judge/judge.go
+++ b/pkg/judge/judge.go
@@ -9,5 +9,5 @@ type Result struct {
 }
 
 type Judge interface {
-	Eval([]interface{}) ([]Result, error)
+	Eval([]map[string]interface{}) ([]Result, error)
 }

--- a/pkg/judge/rego.go
+++ b/pkg/judge/rego.go
@@ -57,7 +57,7 @@ func NewRegoJudge(opts *RegoOpts) (*RegoJudge, error) {
 	return judge, nil
 }
 
-func (j *RegoJudge) Eval(input []interface{}) ([]Result, error) {
+func (j *RegoJudge) Eval(input []map[string]interface{}) ([]Result, error) {
 	ctx := context.Background()
 
 	rs, err := j.preparedQuery.Eval(ctx, rego.EvalInput(input))


### PR DESCRIPTION
This should cover #13 and add better visibility when we fail to parse resources.

The `kubent` will now report details about resource that failed to be parsed:
```
6:07PM ERR Failed to retrieve data from collector error="failed to parse last-applied-configuration annotation of resource default/test-ingress: invalid character '{' looking for beginning of object key s
tring" name=Cluster
```