### PR TITLE
Docs and

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+## kubent Release Notes
+
+### 0.3.0 (2020-08-11)
+
+**Features**:
+- Added stdin support (#19)
+- Added support for reading manifests from files (#15) 
+- Improved Error reporting (#20)
+
+**Fixes**:
+- Support resources without namespace (#14) 
+
+**Internal/misc**:
+- Added first and many other tests (#9, #19), thanks @david-doit-intl 🚀
+- Cleaned up logic in main (#16) 
+- Added release notes and minor deprecated message improvement (#22)
+
+### 0.2.1 (2020-05-24)
+
+**Features**:
+- Added install script (#3, #4)
+
+**Internal/misc**:
+- Moved logic to unpack last-applied config to collector (7)
+
+### 0.2.0 (2020-04-15)
+
+**Fixes**:
+- Produce static binaries (#2) 
+
+### 0.1.0 - Initial Release (2020-04-09)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ particular following tools are supported:
 
 [1]: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
 
+**Additional resources:**
+- Blog post on K8s deprecated APIs and introduction of kubent: [Kubernetes: How to automatically detect and deal with deprecated APIs][2]
+
+[2]: https://blog.doit-intl.com/kubernetes-how-to-automatically-detect-and-deal-with-deprecated-apis-f9a8fc23444c
 
 ## Install
 

--- a/fixtures/deployment-v1beta1-and-ingress-v1beta1.yaml
+++ b/fixtures/deployment-v1beta1-and-ingress-v1beta1.yaml
@@ -19,8 +19,8 @@ spec:
         image: nginx:1.14.2
         ports:
         - containerPort: 80
-apiVersion: extensions/v1beta1
 ---
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/rules/deprecated-1-16.rego
+++ b/rules/deprecated-1-16.rego
@@ -9,7 +9,7 @@ main[return] {
 		"Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
 		"Kind": resource.kind,
 		"ApiVersion": old_api,
-		"RuleSet": "1.16 Deprecated APIs",
+		"RuleSet": "Deprecated APIs removed in 1.16 ",
 	}
 }
 

--- a/rules/deprecated-1-22.rego
+++ b/rules/deprecated-1-22.rego
@@ -9,7 +9,7 @@ main[return] {
 		"Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
 		"Kind": resource.kind,
 		"ApiVersion": old_api,
-		"RuleSet": "1.20 Deprecated APIs",
+		"RuleSet": "Deprecated APIs removed in 1.22",
 	}
 }
 


### PR DESCRIPTION
This PR adds a link to the intro blog post, clarifies the deprecated message in the output and moves Ingress `extensions/v1beta1` deprecation to 1.22.