### PR TITLE
Empty json output to array

### DIFF
--- a/pkg/judge/rego.go
+++ b/pkg/judge/rego.go
@@ -66,7 +66,7 @@ func (j *RegoJudge) Eval(input []map[string]interface{}) ([]Result, error) {
 		return nil, err
 	}
 
-	var results []Result
+	results := []Result{}
 	for _, r := range rs {
 		for _, e := range r.Expressions {
 			for _, i := range e.Value.([]interface{}) {

--- a/pkg/judge/rego_test.go
+++ b/pkg/judge/rego_test.go
@@ -1,0 +1,23 @@
+package judge
+
+import (
+	"testing"
+)
+
+func TestEvalEmpty(t *testing.T) {
+	inputs := []map[string]interface{}{}
+
+	judge, err := NewRegoJudge(&RegoOpts{})
+	if err != nil {
+		t.Errorf("failed to create judge instance: %s", err)
+	}
+
+	results, err := judge.Eval(inputs)
+	if err != nil {
+		t.Errorf("failed to evaluate input: %s", err)
+	}
+
+	if results == nil || len(results) != 0 {
+		t.Errorf("expected empty array, instead got: %v", results)
+	}
+}


### PR DESCRIPTION
This PR makes an empty output (i.e. no issues found) in json format to be an empty array  (instead of null). This is more friendly for CI use (#31), such as with jq.

Before:
```
$./bin/kubent-darwin-amd64 -o json                                                                                                                       2
2:36PM INF >>> Kube No Trouble `kubent` <<<
...
...
null
```

After:
```
$./bin/kubent-darwin-amd64 -o json                                                                                                                     130
3:09PM INF >>> Kube No Trouble `kubent` <<<
...
...
[]
```