### PR TITLE
Add --exit-error (-e) flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ $./kubent -h
 Usage of ./kubent:
   -c, --cluster             enable Cluster collector (default true)
   -d, --debug               enable debug logging
+  -e, --exit-error          exit with non-zero code when issues are found
   -f, --filename strings    manifests to check
       --helm2               enable Helm v2 collector (default true)
       --helm3               enable Helm v3 collector (default true)
@@ -87,10 +88,10 @@ Usage of ./kubent:
 
 ### Use in CI
 
-`kubent` will return `0` exit code if the program succeeds, even if it finds
-deprecated resources, and non-zero exit code if there is an error during
-runtime. Because all info output goes to stderr, it's easy to check in shell if
-any issues were found:
+`kubent` will by default return `0` exit code if the program succeeds, even if
+it finds deprecated resources, and non-zero exit code if there is an error
+during runtime. Because all info output goes to stderr, it's easy to check in
+shell if any issues were found:
 
 ```shell
 test -z "$(kubent)"                 # if stdout output is empty, means no issuse were found
@@ -107,6 +108,9 @@ elif [ -n "${OUTPUT}" ]; then       # check for empty stdout
   echo "Deprecated resources found"
 fi
 ```
+
+You can also use `--exit-error` (`-e`) flag, which will make kubent to exit
+with non-zero return code (`200`) in case any issues are found.
 
 Alternatively, use the json output and smth. like `jq` to check if the result is
 empty:

--- a/cmd/kubent/main.go
+++ b/cmd/kubent/main.go
@@ -22,6 +22,12 @@ var (
 	gitSha  string = "dev"
 )
 
+const (
+	EXIT_CODE_SUCCESS      = 0
+	EXIT_CODE_FAIL_GENERIC = 1
+	EXIT_CODE_FOUND_ISSUES = 200
+)
+
 func getCollectors(collectors []collector.Collector) []map[string]interface{} {
 	var inputs []map[string]interface{}
 	for _, c := range collectors {
@@ -70,6 +76,7 @@ func initCollectors(config *config.Config) []collector.Collector {
 }
 
 func main() {
+	exitCode := EXIT_CODE_FAIL_GENERIC
 
 	config, err := config.NewFromFlags()
 	if err != nil {
@@ -114,4 +121,11 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to print results")
 	}
+
+	if config.ExitError && len(results) > 0 {
+		exitCode = EXIT_CODE_FOUND_ISSUES
+	} else {
+		exitCode = EXIT_CODE_SUCCESS
+	}
+	os.Exit(exitCode)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	Cluster    bool
 	Debug      bool
+	ExitError  bool
 	Filenames  []string
 	Helm2      bool
 	Helm3      bool
@@ -23,6 +24,7 @@ func NewFromFlags() (*Config, error) {
 	home := homedir.HomeDir()
 	flag.BoolVarP(&config.Cluster, "cluster", "c", true, "enable Cluster collector")
 	flag.BoolVarP(&config.Debug, "debug", "d", false, "enable debug logging")
+	flag.BoolVarP(&config.ExitError, "exit-error", "e", false, "exit with non-zero code when issues are found")
 	flag.BoolVar(&config.Helm2, "helm2", true, "enable Helm v2 collector")
 	flag.BoolVar(&config.Helm3, "helm3", true, "enable Helm v3 collector")
 	flag.StringSliceVarP(&config.Filenames, "filename", "f", []string{}, "manifests to check, use - for stdin")


### PR DESCRIPTION
This PR adds `--exit-error` (`-e`) flag for convenience. When enabled this will make `kubent` return non-zero exit code in case any issues are found. Also, tests for exit codes are added. 

Fixes #31.