### PR TITLE
build: Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+    commit-message:
+      prefix: "dep: "
+    reviewers:
+      - "stepanstipl"
+      - "david-doit-intl"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+    commit-message:
+      prefix: "dep: "
+    reviewers:
+      - "stepanstipl"
+      - "david-doit-intl"


### PR DESCRIPTION
This should enable Dependabot and creation of automatic PRs for Go module updates & docker.

Fixes #28 