### PR TITLE
Add changelog generation plumbing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,7 +40,10 @@ jobs:
           scripts/alpine-setup.sh
           GOOS=darwin GOARCH=amd64 make all
           GOOS=linux GOARCH=amd64 make all
+          make changelog
         shell: sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Archive release artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -69,6 +72,7 @@ jobs:
           release_name: Release ${{ steps.get_tag.outputs.git_tag }}
           draft: true
           prerelease: false
+          body_path: ./release-artifacts/changelog.md
       - name: Upload Release Asset - Mac
         id: upload-release-asset-mac
         uses: actions/upload-release-asset@v1

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ RELEASE_DIR ?= release-artifacts
 PACKED_DIR ?= $(BIN_DIR)/packed
 CMDS ?= $(shell ls $(CMD_DIR))
 BINS ?= $(addsuffix -$(GOOS)-$(GOARCH),$(addprefix $(BIN_DIR)/,$(CMDS)))
+CHANGELOG ?= changelog.md
 
 BIN_ARCH ?= $(GOOS)-$(GOARCH)
 RELEASE_SUFFIX ?= $(GIT_REF)-$(BIN_ARCH).tar.gz
@@ -118,3 +119,8 @@ clean:
 	rm -rf $(GENERATE_DIR)
 	rm -rf $(BIN_DIR)
 .PHONY: clean
+
+## Generate Changelog based on PRs
+changelog:
+	OUTPUT_FILE=$(RELEASE_DIR)/$(CHANGELOG) ./scripts/github-changelog.sh
+.PHONY: changelog

--- a/README.md
+++ b/README.md
@@ -178,6 +178,31 @@ Use imperative, present tense (Add, not ~Added~), capitalize first letter of
 summary, no dot at the and. The body and footer are optional. Relevant GitHub
 issues should be referenced in the footer in the form `Fixes #123, fixes #456`.
 
+### Changelog
+
+Changelog is generated automatically based on merged PRs using
+[changelog-gen][chlg-gen]. Template can be found in `scripts/changelog.tmpl`.
+
+PRs are categorized based on their labels, into following sections:
+- Announcements - `announcement` label
+- Breaking Changes - `breaking-change` label
+- Features - `feature` label
+- Changes - `change` label
+- Fixes - `fix` label
+- Internal/Other - everything else
+
+PR can be excluded from changelog with `no-release-note` label. PR title is
+used by default, however, the copy can be customized by including following
+block in the PR body:
+
+~~~
+```release-note
+This is an example release note!
+```
+~~~
+
+[chlg-gen]: https://github.com/paultyng/changelog-gen
+
 ## Issues and Contributions
 
 Please open any issues and/or PRs against github.com/doitintl/kube-no-trouble repository.

--- a/scripts/alpine-setup.sh
+++ b/scripts/alpine-setup.sh
@@ -10,6 +10,7 @@ OPA_VERSION="0.22.0"
 apk add --update --no-cache \
 	curl \
 	git \
+	jq \
 	make \
 	tar
 

--- a/scripts/alpine-setup.sh
+++ b/scripts/alpine-setup.sh
@@ -8,6 +8,7 @@ UPX_VERSION="3.96"
 OPA_VERSION="0.22.0"
 
 apk add --update --no-cache \
+	curl \
 	git \
 	make \
 	tar

--- a/scripts/alpine-setup.sh
+++ b/scripts/alpine-setup.sh
@@ -20,3 +20,4 @@ wget -q -O "/usr/local/bin/opa" "https://github.com/open-policy-agent/opa/releas
 chmod +x "/usr/local/bin/opa"
 
 go get github.com/rakyll/statik
+go get github.com/paultyng/changelog-gen

--- a/scripts/changelog.tmpl
+++ b/scripts/changelog.tmpl
@@ -1,0 +1,68 @@
+{{- $announcements := newStringList -}}
+{{- $breaking := newStringList -}}
+{{- $features := newStringList -}}
+{{- $changes := newStringList -}}
+{{- $fixes := newStringList -}}
+{{- $other := newStringList -}}
+
+{{- range . -}}
+  {{if has "announcement" .Labels -}}
+	{{$features = append $announcements (renderReleaseNote .) -}}
+  {{else if .BreakingChange -}}
+	{{$breaking = append $breaking (renderReleaseNote .) -}}
+  {{else if has "feature" .Labels -}}
+	{{$features = append $features (renderReleaseNote .) -}}
+  {{else if has "change" .Labels -}}
+	{{$fixes = append $changes (renderReleaseNote .) -}}
+  {{else if has "fix" .Labels -}}
+	{{$fixes = append $fixes (renderReleaseNote .) -}}
+  {{else -}}
+	{{$other = append $other (renderReleaseNote .) -}}
+  {{end -}}
+{{- end -}}
+
+{{- if gt (len $announcements) 0 -}}
+{{range $announcements | sortAlpha -}}
+{{. }}
+{{end -}}
+{{- end -}}
+
+{{- if gt (len $breaking) 0 -}}
+**Breaking Changes**:
+
+{{range $breaking | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+
+{{- if gt (len $features) 0}}
+**Features**:
+
+{{range $features | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+
+{{- if gt (len $changes) 0}}
+**Changes**:
+
+{{range $changes | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+
+{{- if gt (len $fixes) 0}}
+**Fixes**:
+
+{{range $fixes | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+
+{{- if gt (len $other) 0}}
+**Internal/Other**:
+
+{{range $other | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}

--- a/scripts/github-changelog.sh
+++ b/scripts/github-changelog.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# Set strict error checking
+set -emou pipefail
+
+GH_ORG="doitintl"
+GH_REPO="kube-no-trouble"
+CHANGELOG_TEMPLATE="./scripts/changelog.tmpl"
+OUTPUT_FILE="${OUTPUT_FILE:="./changelog.md"}"
+
+RELEASE_SHA="$(curl --silent "https://api.github.com/repos/${GH_ORG}/${GH_REPO}/releases/latest" \
+	| jq -r '.target_commitish')"
+MASTER_SHA="$(git rev-parse origin/master)"
+
+echo "- Generating changelog (${OUTPUT_FILE})"
+
+changelog-gen -changelog "${CHANGELOG_TEMPLATE}" \
+	-owner "${GH_ORG}" -repo "${GH_REPO}" \
+	"${RELEASE_SHA}" "${MASTER_SHA}" | tee "${OUTPUT_FILE}"


### PR DESCRIPTION
This PR adds tooling and plumbing for changelog generation, based on PRs and their labels.

Initially to be used to prepare changelog for releases (still manual step) and for nightly releases (fully automated). Details are described in README.