### PR TITLE
Removing whitespace at the end of the ruleset 1.16 msg

### DIFF
--- a/rules/deprecated-1-16.rego
+++ b/rules/deprecated-1-16.rego
@@ -9,7 +9,7 @@ main[return] {
 		"Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
 		"Kind": resource.kind,
 		"ApiVersion": old_api,
-		"RuleSet": "Deprecated APIs removed in 1.16 ",
+		"RuleSet": "Deprecated APIs removed in 1.16",
 	}
 }
 


### PR DESCRIPTION
Hi again 👋 ! 

I've found that the msg of the 1.16 deprecation ruleset has an extra whitespace at the end, I think it's a little bit annoying for consuming the json output with `jq`  so I removed it in this PR. 

Let me know if that's ok.

Thanks!