### PR TITLE
ci: Only consider x.y.z releases for builiding nightly tags

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Set tag name
         id: git_tag
-        run: echo "::set-output name=tag::$(git describe --tags)"
+        run: echo "::set-output name=tag::$(git describe --tags --match '[0-9].[0-9].[0-9]')"
 
       - name: check if tag exists
         id: tag_exists


### PR DESCRIPTION
Only releases (x.y.z) should be considered for deriving nightly build names.

This should prevent issue like `nightly-nightly-0.3.2-xx-test-4-g8092735`, which was derived from `nightly-0.3.2-xx-test`.