### PR TITLE
ci: Prevent runs if nightly tag exists

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,7 +20,9 @@ jobs:
         id: tag_exists
         run: |
           set -x
-          [ "$(git tag -l "${TAG}")" = "${TAG}" ] && exists=true || exists=false
+          exists=false
+          [ "$(git tag -l "${TAG}")" = "${TAG}" ] && exists=true
+          [ "$(git tag -l "nightly-${TAG}")" = "nightly-${TAG}" ] && exists=true
           echo "::set-output name=result::${exists}"
         env:
           TAG: ${{ steps.git_tag.outputs.tag }}


### PR DESCRIPTION
This should fix unintended nightly runs if the nightly tag does exists, such as:

https://github.com/doitintl/kube-no-trouble/runs/1561223081?check_suite_focus=true