### PR TITLE
feat: Add deprecation rules (coordination, authentication, authorization) in 1.22 ruleset

### DIFF
--- a/fixtures/fake-tokenReview-deprecated.yaml
+++ b/fixtures/fake-tokenReview-deprecated.yaml
@@ -1,0 +1,6 @@
+apiVersion: authentication.k8s.io/v1beta1
+kind: TokenReview
+metadata:
+  name: test-deprecated-TokenReview
+spec:
+    token: exampletoken

--- a/rules/deprecated-1-22.rego
+++ b/rules/deprecated-1-22.rego
@@ -20,11 +20,33 @@ deprecated_resource(r) = api {
 }
 
 deprecated_api(kind, api_version) = api {
-	deprecated_apis = {"Ingress": {
-		"old": ["extensions/v1beta1"],
-		"new": "networking.k8s.io/v1beta1",
-		"since": "1.14",
-	}}
+	deprecated_apis = {
+		"Ingress": {
+			"old": ["extensions/v1beta1"],
+			"new": "networking.k8s.io/v1beta1",
+			"since": "1.14",
+		},
+		"TokenReview": {
+			"old": ["authentication.k8s.io/v1beta1"],
+			"new": "authentication.k8s.io/v1",
+			"since": "1.19",
+		},
+		"SubjectAccessReview": {
+			"old": ["authorization.k8s.io/v1beta1"],
+			"new": "authorization.k8s.io/v1",
+			"since": "1.19",
+		},
+		"Lease": {
+			"old": ["coordination.k8s.io/v1beta1"],
+			"new": "coordination.k8s.io/v1",
+			"since": "1.19",
+		},
+		"LeaseList": {
+			"old": ["coordination.k8s.io/v1beta1"],
+			"new": "coordination.k8s.io/v1",
+			"since": "1.19",
+		},
+	}
 
 	deprecated_apis[kind].old[_] == api_version
 


### PR DESCRIPTION
This PR add depreciation rules for following API:

- Coordination.k8s.io/v1beta1  _(target removal in 1.22)_
- authentication.k8s.io/v1beta1 _(removed in 1.22)_
- authorization.k8s.io/v1beta1 _(removed in 1.22)_

source :
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#deprecation
