### PR TITLE
fix: Deprecated networking.k8s.io/v1beta1

### DIFF
--- a/rules/deprecated-1-22.rego
+++ b/rules/deprecated-1-22.rego
@@ -23,7 +23,12 @@ deprecated_api(kind, api_version) = api {
 	deprecated_apis = {
 		"Ingress": {
 			"old": ["extensions/v1beta1"],
-			"new": "networking.k8s.io/v1beta1",
+			"new": "networking.k8s.io/v1",
+			"since": "1.14",
+		},
+		"Ingress": {
+			"old": ["networking.k8s.io/v1beta1"],
+			"new": "networking.k8s.io/v1",
 			"since": "1.14",
 		},
 		"TokenReview": {


### PR DESCRIPTION
Fix https://github.com/doitintl/kube-no-trouble/issues/94