### PR TITLE
feat: Add support for custom resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ debug.test
 # Editor files
 .vscode
 .swp
+.idea
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ test: test-fmt test-git
 
 ## Run go and opt fmt checks
 test-fmt:
-	test -z "$$(opa fmt -l rules/*)"
+	test -z "$$(opa fmt -l pkg/rules/rego/*)"
 	test -z "$$(go fmt ./...)"
 .PHONY: test-fmt
 

--- a/README.md
+++ b/README.md
@@ -76,15 +76,20 @@ You can list all the configuration options available using `--help` switch:
 ```sh
 $./kubent -h
 Usage of ./kubent:
-  -c, --cluster             enable Cluster collector (default true)
-  -d, --debug               enable debug logging
-  -e, --exit-error          exit with non-zero code when issues are found
-  -f, --filename strings    manifests to check
-      --helm2               enable Helm v2 collector (default true)
-      --helm3               enable Helm v3 collector (default true)
-  -k, --kubeconfig string   path to the kubeconfig file (default "/Users/stepan/.kube/config")
-  -o, --output string       output format - [text|json] (default "text")
+  -a, --additional-kind strings   additional kinds of resources to report in Kind.version.group.com format
+  -c, --cluster                   enable Cluster collector (default true)
+  -d, --debug                     enable debug logging
+  -e, --exit-error                exit with non-zero code when issues are found
+  -f, --filename strings          manifests to check, use - for stdin
+      --helm2                     enable Helm v2 collector (default true)
+      --helm3                     enable Helm v3 collector (default true)
+  -k, --kubeconfig string         path to the kubeconfig file (default "/Users/stepan/.kube/config")
+  -o, --output string             output format - [text|json] (default "text")
 ```
+
+- *`-a, --additional-kind`*
+  Tells `kubent` to flag additional custom resources when found in the specified version. The flag can be used multiple
+  times. The expected format is full *Kind.version.group.com* form - e.g. `-a ManagedCertificate.v1.networking.gke.io`.
 
 ### Use in CI
 

--- a/cmd/kubent/main.go
+++ b/cmd/kubent/main.go
@@ -55,7 +55,7 @@ func storeCollector(collector collector.Collector, err error, collectors []colle
 func initCollectors(config *config.Config) []collector.Collector {
 	collectors := []collector.Collector{}
 	if config.Cluster {
-		collector, err := collector.NewClusterCollector(&collector.ClusterOpts{Kubeconfig: config.Kubeconfig})
+		collector, err := collector.NewClusterCollector(&collector.ClusterOpts{Kubeconfig: config.Kubeconfig}, config.AdditionalKinds)
 		collectors = storeCollector(collector, err, collectors)
 	}
 

--- a/cmd/kubent/main.go
+++ b/cmd/kubent/main.go
@@ -80,13 +80,14 @@ func initCollectors(config *config.Config) []collector.Collector {
 func main() {
 	exitCode := EXIT_CODE_FAIL_GENERIC
 
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
 	config, err := config.NewFromFlags()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to parse config flags")
 	}
 
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	if config.Debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}

--- a/fixtures/issuer-v1alpha2.yaml
+++ b/fixtures/issuer-v1alpha2.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: sandbox
+spec:
+  selfSigned: {}

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -4,23 +4,30 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 type ClusterCollector struct {
 	*commonCollector
-	clientSet dynamic.Interface
+	clientSet           dynamic.Interface
+	discoveryClient     discovery.DiscoveryInterface
+	additionalResources []schema.GroupVersionResource
 }
 
 type ClusterOpts struct {
-	Kubeconfig string
-	ClientSet  dynamic.Interface
+	Kubeconfig      string
+	ClientSet       dynamic.Interface
+	DiscoveryClient discovery.DiscoveryInterface
 }
 
-func NewClusterCollector(opts *ClusterOpts) (*ClusterCollector, error) {
+func NewClusterCollector(opts *ClusterOpts, additionalKinds []string) (*ClusterCollector, error) {
 	collector := &ClusterCollector{commonCollector: &commonCollector{name: "Cluster"}}
 
 	if opts.ClientSet == nil {
@@ -33,8 +40,36 @@ func NewClusterCollector(opts *ClusterOpts) (*ClusterCollector, error) {
 		if err != nil {
 			return nil, err
 		}
+
 	} else {
 		collector.clientSet = opts.ClientSet
+	}
+
+	if opts.DiscoveryClient == nil {
+		config, err := clientcmd.BuildConfigFromFlags("", opts.Kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+
+		collector.discoveryClient, err = discovery.NewDiscoveryClientForConfig(config)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		collector.discoveryClient = opts.DiscoveryClient
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(collector.discoveryClient))
+	for _, ar := range additionalKinds {
+		gvk, _ := schema.ParseKindArg(ar)
+
+		gvrMap, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			log.Warn().Msgf("Failed to map %s Kind to resource: %s", gvk.Kind, err)
+			continue
+		}
+
+		collector.additionalResources = append(collector.additionalResources, gvrMap.Resource)
 	}
 
 	return collector, nil
@@ -50,13 +85,16 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"},
 		schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "ingresses"},
 	}
+	gvrs = append(gvrs, c.additionalResources...)
 
 	var results []map[string]interface{}
 	for _, g := range gvrs {
 		ri := c.clientSet.Resource(g)
+		log.Debug().Msgf("Retrieving: %s.%s.%s", g.Resource, g.Version, g.Group)
 		rs, err := ri.List(metav1.ListOptions{})
 		if err != nil {
-			return nil, err
+			log.Warn().Msgf("Failed to retrieve: %s: %s", g, err)
+			continue
 		}
 
 		for _, r := range rs.Items {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,28 +1,34 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"unicode"
 
+	"github.com/rs/zerolog/log"
 	flag "github.com/spf13/pflag"
 	"k8s.io/client-go/util/homedir"
 )
 
 type Config struct {
-	Cluster    bool
-	Debug      bool
-	ExitError  bool
-	Filenames  []string
-	Helm2      bool
-	Helm3      bool
-	Kubeconfig string
-	Output     string
+	AdditionalKinds []string
+	Cluster         bool
+	Debug           bool
+	ExitError       bool
+	Filenames       []string
+	Helm2           bool
+	Helm3           bool
+	Kubeconfig      string
+	Output          string
 }
 
 func NewFromFlags() (*Config, error) {
 	config := Config{}
 
 	home := homedir.HomeDir()
+	flag.StringSliceVarP(&config.AdditionalKinds, "additional-kind", "a", []string{}, "additional kinds of resources to report in Kind.version.group.com format")
 	flag.BoolVarP(&config.Cluster, "cluster", "c", true, "enable Cluster collector")
 	flag.BoolVarP(&config.Debug, "debug", "d", false, "enable debug logging")
 	flag.BoolVarP(&config.ExitError, "exit-error", "e", false, "exit with non-zero code when issues are found")
@@ -34,6 +40,10 @@ func NewFromFlags() (*Config, error) {
 
 	flag.Parse()
 
+	if err := validateAdditionalResources(config.AdditionalKinds); err != nil {
+		return nil, fmt.Errorf("failed to validate arguments: %w", err)
+	}
+
 	return &config, nil
 }
 
@@ -43,4 +53,21 @@ func envOrString(env string, def string) string {
 		return val
 	}
 	return def
+}
+
+// validateAdditionalResources check that all resources are provided in full form
+// resource.version.group.com. E.g. managedcertificate.v1beta1.networking.gke.io
+func validateAdditionalResources(resources []string) error {
+	for _, r := range resources {
+		parts := strings.Split(r, ".")
+		log.Debug().Msgf("parts: %+v", parts)
+		if len(parts) < 4 {
+			return fmt.Errorf("failed to parse additional Kind, full form Kind.version.group.com is expected, instead got: %s", r)
+		}
+
+		if !unicode.IsUpper(rune(parts[0][0])) {
+			return fmt.Errorf("failed to parse additional Kind, Kind is expected to be capitalized by convention, instead got: %s", parts[0])
+		}
+	}
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/spf13/pflag"
-	"k8s.io/client-go/util/homedir"
 	"os"
 	"testing"
+
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/util/homedir"
 )
 
 func TestNewFromFlags(t *testing.T) {
@@ -87,5 +88,35 @@ func TestEnvOrStringDefault(t *testing.T) {
 	i := envOrString("FOO", "default")
 	if i != "default" {
 		t.Errorf("Expected to get default string, got %s instead", i)
+	}
+}
+
+func TestValidateAdditionalResources(t *testing.T) {
+	resources := []string{
+		"Test.v1.example.com",
+		"ManagedCertificates.v1.networking.gke.io",
+		"ManagedCertificates.networking.gke.io",
+	}
+
+	err := validateAdditionalResources(resources)
+
+	if err != nil {
+		t.Errorf("expected resources %s to pass validation: %s", resources, err)
+	}
+}
+
+func TestValidateAdditionalResourcesFail(t *testing.T) {
+	testCases := [][]string{
+		[]string{"abcdef"},
+		[]string{""},
+		[]string{"test.v1.com"},
+	}
+
+	for _, tc := range testCases {
+		err := validateAdditionalResources(tc)
+
+		if err == nil {
+			t.Errorf("expected resources %s to fail validation: %s", tc, err)
+		}
 	}
 }

--- a/pkg/judge/rego_test.go
+++ b/pkg/judge/rego_test.go
@@ -1,10 +1,12 @@
 package judge
 
 import (
-	"github.com/doitintl/kube-no-trouble/pkg/rules"
-	"github.com/ghodss/yaml"
 	"io/ioutil"
 	"testing"
+
+	"github.com/doitintl/kube-no-trouble/pkg/rules"
+	"github.com/ghodss/yaml"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestNewRegoJudge(t *testing.T) {
@@ -65,7 +67,7 @@ func TestEvalRules(t *testing.T) {
 				manifests = append(manifests, manifest)
 			}
 
-			loadedRules, err := rules.FetchRegoRules()
+			loadedRules, err := rules.FetchRegoRules([]schema.GroupVersionKind{})
 			if err != nil {
 				t.Errorf("Failed to load rules")
 			}

--- a/pkg/rules/rego/custom.rego.tmpl
+++ b/pkg/rules/rego/custom.rego.tmpl
@@ -1,0 +1,42 @@
+{{/* this template will be rendered with []schema.GroupVersionKind data */}}
+package custom
+
+main[return] {
+	resource := input[_]
+	api := deprecated_resource(resource)
+	return := {
+		"Name": resource.metadata.name,
+		# Namespace does not have to be defined in case of local manifests
+		"Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
+		"Kind": resource.kind,
+		"ApiVersion": api.old,
+		"ReplaceWith": "<na>",
+		"RuleSet": "Additional resources (custom)",
+		"Since": "<na>",
+	}
+}
+
+deprecated_resource(r) = api {
+	api := deprecated_api(r.kind, r.apiVersion)
+}
+
+deprecated_api(kind, api_version) = api {
+	deprecated_apis = {
+{{- range . }}
+		"{{ .Kind }}": {
+			"old": ["{{ .Group }}/{{ .Version }}"],
+		},
+{{- end }}
+	}
+
+	deprecated_apis[kind].old[_] == api_version
+	api := {
+		"old": api_version,
+	}
+}
+
+get_default(val, key, _) = val[key]
+
+get_default(val, key, fallback) = fallback {
+	not val[key]
+}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -1,9 +1,17 @@
 package rules
 
 import (
+	"bytes"
 	"embed"
+	"fmt"
+	"html/template"
 	"path"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+const RULES_DIR = "rego"
 
 //go:embed rego
 var local embed.FS
@@ -13,23 +21,57 @@ type Rule struct {
 	Rule string
 }
 
-func FetchRegoRules() ([]Rule, error) {
-	fis, err := local.ReadDir("rego")
+func FetchRegoRules(additionalResources []schema.GroupVersionKind) ([]Rule, error) {
+	fis, err := local.ReadDir(RULES_DIR)
 	if err != nil {
 		return nil, err
 	}
 
-	rules := []Rule{}
+	var rules []Rule
 	for _, info := range fis {
-		data, err := local.ReadFile(path.Join("rego", info.Name()))
+		data, err := local.ReadFile(path.Join(RULES_DIR, info.Name()))
 		if err != nil {
 			return nil, err
 		}
+
+		rule, err := renderRule(data, info.Name(), additionalResources)
+		if err != nil {
+			return nil, err
+		}
+
 		rules = append(rules, Rule{
 			Name: info.Name(),
-			Rule: string(data),
+			Rule: string(rule),
 		})
 	}
 
 	return rules, nil
+}
+
+func renderRule(inputData []byte, fileName string, additionalKinds []schema.GroupVersionKind) ([]byte, error) {
+	var data []byte
+
+	switch {
+	case strings.HasSuffix(fileName, ".rego"):
+		data = inputData
+
+	// currently this is relevant only to additional resources
+	case strings.HasSuffix(fileName, ".tmpl"):
+		t, err := template.New(fileName).Parse(string(inputData))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse template %s: %w", fileName, err)
+		}
+
+		var tpl bytes.Buffer
+		if err := t.Execute(&tpl, additionalKinds); err != nil {
+			return nil, fmt.Errorf("failed to render template %s: %w", fileName, err)
+		}
+
+		data = tpl.Bytes()
+
+	default:
+		return nil, fmt.Errorf("unrecognized filetype: %s", fileName)
+	}
+
+	return data, nil
 }

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -1,9 +1,12 @@
 package rules
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestFetchRules(t *testing.T) {
@@ -16,7 +19,7 @@ func TestFetchRules(t *testing.T) {
 		return nil
 	})
 
-	rules, err := FetchRegoRules()
+	rules, err := FetchRegoRules([]schema.GroupVersionKind{})
 	if err != nil {
 		t.Errorf("Failed to load rules with: %s", err)
 	}
@@ -24,5 +27,94 @@ func TestFetchRules(t *testing.T) {
 		if rule.Name != expected[i] {
 			t.Errorf("expected to get %s finding, instead got: %s", expected[i], rule.Name)
 		}
+	}
+}
+
+func TestFetchRulesWithAdditionalResources(t *testing.T) {
+	var expected []string
+	err := filepath.Walk(RULES_DIR, func(path string, info os.FileInfo, err error) error {
+		if info.Name() != RULES_DIR {
+			expected = append(expected, info.Name())
+		}
+		return nil
+	})
+
+	additionalKindsStr := []string{
+		"ManagedCertificate.v1.networking.gke.io",
+		"Fake.v1beta.example.com"}
+	var additionalKinds []schema.GroupVersionKind
+	for _, ar := range additionalKindsStr {
+		gvr, _ := schema.ParseKindArg(ar)
+		additionalKinds = append(additionalKinds, *gvr)
+	}
+
+	rules, err := FetchRegoRules([]schema.GroupVersionKind{})
+	if err != nil {
+		t.Errorf("Failed to load rules with: %s", err)
+	}
+	for i, rule := range rules {
+		if rule.Name != expected[i] {
+			t.Errorf("expected to get %s finding, instead got: %s", expected[i], rule.Name)
+		}
+	}
+}
+
+func TestRenderRuleRego(t *testing.T) {
+	inputData := []byte("some input")
+	fileName := "test.rego"
+
+	outputData, err := renderRule(inputData, fileName, []schema.GroupVersionKind{})
+	if err != nil {
+		t.Errorf("Failed to render rule %s: %s", fileName, err)
+	}
+
+	if bytes.Compare(inputData, outputData) != 0 {
+		t.Errorf("expected the input to be same as output")
+	}
+}
+
+func TestRenderRuleTmpl(t *testing.T) {
+	additionalResources := []schema.GroupVersionKind{
+		schema.GroupVersionKind{
+			Group:   "example.com",
+			Version: "v2",
+			Kind:    "Test",
+		},
+	}
+	fileName := "test.tmpl"
+	inputData := []byte("{{- range . }}" +
+		"{{ .Kind }}.{{ .Version }}.{{ .Group }}" +
+		"{{- end }}")
+	expectedData := []byte("Test.v2.example.com")
+
+	outputData, err := renderRule(inputData, fileName, additionalResources)
+	if err != nil {
+		t.Errorf("failed to render rule %s: %s", fileName, err)
+	}
+
+	if bytes.Compare(expectedData, outputData) != 0 {
+		t.Errorf("result does not match expected output, expected: %s, got: %s", expectedData, outputData)
+	}
+}
+
+func TestRenderRuleTmplFail(t *testing.T) {
+	fileName := "test.tmpl"
+	inputData := []byte("{{- rangeasd . }}" +
+		"{{ .Kind }}.{{ .Version }}.{{ Group }}" +
+		"{{- end }}")
+
+	_, err := renderRule(inputData, fileName, []schema.GroupVersionKind{})
+	if err == nil {
+		t.Errorf("expected this to fail")
+	}
+}
+
+func TestRenderRuleUnknownFail(t *testing.T) {
+	inputData := []byte("some input")
+	fileName := "test.txt"
+
+	_, err := renderRule(inputData, fileName, []schema.GroupVersionKind{})
+	if err == nil {
+		t.Errorf("expected this to fail")
 	}
 }

--- a/test/rules_test.go
+++ b/test/rules_test.go
@@ -1,0 +1,61 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/doitintl/kube-no-trouble/pkg/collector"
+	"github.com/doitintl/kube-no-trouble/pkg/judge"
+	"github.com/doitintl/kube-no-trouble/pkg/rules"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestRegoCustom(t *testing.T) {
+	manifestName := "../fixtures/issuer-v1alpha2.yaml"
+	expectedKind := "Issuer"
+	additionalKinds := []schema.GroupVersionKind{
+		schema.GroupVersionKind{
+			Group:   "cert-manager.io",
+			Version: "v1alpha2",
+			Kind:    "Issuer",
+		},
+	}
+
+	c, err := collector.NewFileCollector(
+		&collector.FileOpts{Filenames: []string{manifestName}},
+	)
+
+	if err != nil {
+		t.Errorf("expected to succeed for %s, failed: %s", manifestName, err)
+	}
+
+	manifests, err := c.Get()
+	if err != nil {
+		t.Errorf("expected to succeed for %s, failed: %s", manifestName, err)
+	} else if len(manifests) == 0 {
+		t.Errorf("expected to get some manifests, got %d", len(manifests))
+	}
+
+	loadedRules, err := rules.FetchRegoRules(additionalKinds)
+	if err != nil {
+		t.Errorf("failed to load rules: %s", err)
+	}
+
+	judge, err := judge.NewRegoJudge(&judge.RegoOpts{}, loadedRules)
+	if err != nil {
+		t.Errorf("failed to initialize judge: %s", err)
+	}
+
+	results, err := judge.Eval(manifests)
+	if err != nil {
+		t.Errorf("failed to evaluate rules: %s", err)
+	}
+
+	if len(results) == 0 {
+		t.Errorf("expected to get some manifests, got %d", len(results))
+	}
+
+	if results[0].Kind != expectedKind {
+		t.Errorf("expected to get %s result, got %s", expectedKind, results[0].Kind)
+	}
+}


### PR DESCRIPTION
~*WIP: Still needs:*~
- [x] ~docs update~
- [x] ~(at least) some test coverage~
- [x] ~test to test the custom rule~
- [x] ~squash before merge~

---

This PR adds support for detecting and flagging custom resources.
```
kubent -a "ManagedCertificate.v1.networking.gke.io"
```

The `-a` flag, or it's full form `--additional-kind`, can be used multiple times.
The expected format is full `Kind.version.group.com` form - e.g. `ManagedCertificate.v1.networking.gke.io`.


Closes #44