### PR TITLE
feat: jsonl output and quiet stdout

### DIFF
--- a/cmd/kubent/main.go
+++ b/cmd/kubent/main.go
@@ -89,6 +89,9 @@ func main() {
 	if config.Debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
+	if config.Quiet {
+		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	}
 
 	log.Info().Msg(">>> Kube No Trouble `kubent` <<<")
 	log.Info().Msgf("version %s (git sha %s)", version, gitSha)
@@ -114,8 +117,8 @@ func main() {
 
 	var prnt printer.Printer
 	switch config.Output {
-	case "json":
-		prnt, err = printer.NewJSONPrinter(&printer.JSONOpts{})
+	case "json", "jsonl":
+		prnt, err = printer.NewJSONPrinter(&printer.JSONOpts{OnePerLine: config.Output == "jsonl"})
 	default:
 		prnt, err = printer.NewTextPrinter(&printer.TextOpts{})
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	Cluster    bool
 	Debug      bool
+	Quiet      bool
 	ExitError  bool
 	Filenames  []string
 	Helm2      bool
@@ -25,12 +26,13 @@ func NewFromFlags() (*Config, error) {
 	home := homedir.HomeDir()
 	flag.BoolVarP(&config.Cluster, "cluster", "c", true, "enable Cluster collector")
 	flag.BoolVarP(&config.Debug, "debug", "d", false, "enable debug logging")
+	flag.BoolVarP(&config.Quiet, "quiet", "q", false, "disable logging output (other than critical errors)")
 	flag.BoolVarP(&config.ExitError, "exit-error", "e", false, "exit with non-zero code when issues are found")
 	flag.BoolVar(&config.Helm2, "helm2", true, "enable Helm v2 collector")
 	flag.BoolVar(&config.Helm3, "helm3", true, "enable Helm v3 collector")
 	flag.StringSliceVarP(&config.Filenames, "filename", "f", []string{}, "manifests to check, use - for stdin")
 	flag.StringVarP(&config.Kubeconfig, "kubeconfig", "k", envOrString("KUBECONFIG", filepath.Join(home, ".kube", "config")), "path to the kubeconfig file")
-	flag.StringVarP(&config.Output, "output", "o", "text", "output format - [text|json]")
+	flag.StringVarP(&config.Output, "output", "o", "text", "output format - [text|json|jsonl]")
 
 	flag.Parse()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/spf13/pflag"
-	"k8s.io/client-go/util/homedir"
 	"os"
 	"testing"
+
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/util/homedir"
 )
 
 func TestNewFromFlags(t *testing.T) {

--- a/pkg/judge/rego_test.go
+++ b/pkg/judge/rego_test.go
@@ -1,10 +1,11 @@
 package judge
 
 import (
-	"github.com/doitintl/kube-no-trouble/pkg/rules"
-	"github.com/ghodss/yaml"
 	"io/ioutil"
 	"testing"
+
+	"github.com/doitintl/kube-no-trouble/pkg/rules"
+	"github.com/ghodss/yaml"
 )
 
 func TestNewRegoJudge(t *testing.T) {
@@ -84,7 +85,7 @@ func TestEvalRules(t *testing.T) {
 				t.Errorf("expected %d findings, instead got: %d", len(tc.expected), len(results))
 			}
 
-			for i, _ := range results {
+			for i := range results {
 				if results[i].Kind != tc.expected[i] {
 					t.Errorf("expected to get %s finding, instead got: %s", tc.expected[i], results[i].Kind)
 				}

--- a/pkg/printer/json.go
+++ b/pkg/printer/json.go
@@ -9,27 +9,50 @@ import (
 )
 
 type JSONPrinter struct {
+	opts *JSONOpts
 }
 
 type JSONOpts struct {
+	// OnePerLine enables JSONL support
+	OnePerLine bool
 }
 
 func NewJSONPrinter(opts *JSONOpts) (*JSONPrinter, error) {
-	printer := &JSONPrinter{}
+	printer := &JSONPrinter{opts: opts}
 
 	return printer, nil
 }
 
 func (c *JSONPrinter) Print(results []judge.Result) error {
-
 	buffer := new(bytes.Buffer)
-	encoder := json.NewEncoder(buffer)
-	encoder.SetIndent("", "\t")
 
-	err := encoder.Encode(results)
-	if err != nil {
-		return err
+	if !c.opts.OnePerLine {
+		encoder := json.NewEncoder(buffer)
+		encoder.SetIndent("", "\t")
+
+		err := encoder.Encode(results)
+		if err != nil {
+			return err
+		}
+	} else {
+		for _, entry := range results {
+			b, err := json.Marshal(entry)
+			if err != nil {
+				return err
+			}
+
+			_, err = buffer.Write(b)
+			if err != nil {
+				return err
+			}
+
+			err = buffer.WriteByte('\n')
+			if err != nil {
+				return err
+			}
+		}
 	}
+
 	fmt.Printf("%s", buffer.String())
 
 	return nil

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -1,0 +1,114 @@
+package printer
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/doitintl/kube-no-trouble/pkg/judge"
+)
+
+var findingsJsonTesting []judge.Result = []judge.Result{
+	{
+		Name:        "testName1",
+		Kind:        "testKind1",
+		Namespace:   "testNamespace1",
+		ApiVersion:  "v1",
+		RuleSet:     "testRuleset1",
+		ReplaceWith: "testReplaceWith1",
+		Since:       "testSince1",
+	},
+	{
+		Name:        "testName2",
+		Kind:        "testKind2",
+		Namespace:   "testNamespace2",
+		ApiVersion:  "v1",
+		RuleSet:     "testRuleset2",
+		ReplaceWith: "testReplaceWith2",
+		Since:       "testSince2",
+	},
+}
+
+func captureOutput(f func([]judge.Result) error, r []judge.Result) (string, error) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+		log.SetOutput(os.Stderr)
+	}()
+	os.Stdout = writer
+	os.Stderr = writer
+	log.SetOutput(writer)
+	out := make(chan string)
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		var buf bytes.Buffer
+		wg.Done()
+		io.Copy(&buf, reader)
+		out <- buf.String()
+	}()
+	wg.Wait()
+	err = f(r)
+	writer.Close()
+	return <-out, err
+}
+
+func TestNewJsonPrinter(t *testing.T) {
+	jsonPrinter, _ := NewJSONPrinter(&JSONOpts{})
+	if jsonPrinter.opts.OnePerLine != false {
+		t.Errorf("OnePerLine should default to false")
+	}
+
+	jsonPrinter, _ = NewJSONPrinter(&JSONOpts{OnePerLine: true})
+	if jsonPrinter.opts.OnePerLine != true {
+		t.Errorf("OnePerLine should default to true")
+	}
+}
+
+func TestPrintJson(t *testing.T) {
+	jsonPrinter, _ := NewJSONPrinter(&JSONOpts{OnePerLine: false})
+	output, _ := captureOutput(jsonPrinter.Print, findingsJsonTesting)
+
+	var j []judge.Result
+	err := json.Unmarshal([]byte(output), &j)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(j) != 2 {
+		t.Error("wrong number of results")
+	}
+}
+
+func TestPrintJsonL(t *testing.T) {
+	x, _ := NewJSONPrinter(&JSONOpts{OnePerLine: true})
+	output, _ := captureOutput(x.Print, findingsJsonTesting)
+
+	if len(strings.Split(output, "\n")) != 3 {
+		t.Errorf("execting two lines and got %d", len(strings.Split(output, "\n")))
+	}
+
+	for _, line := range strings.Split(output, "\n") {
+		if len(line) > 0 {
+			var j judge.Result
+			err := json.Unmarshal([]byte(line), &j)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !strings.HasPrefix(j.Name, "testName") {
+				t.Errorf("unexpected name")
+			}
+		}
+	}
+}


### PR DESCRIPTION
To support better automated usage.

New options:

 * -q will quiet the stderr log output
 * -o jsonl will, instead out outputting a list, output one infraction
   per line. This is good if you're loading the data into data
   warehouses or other reporting tools.