### PR TITLE
ci: Fix failing Upload Release Asset steps

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,6 +57,9 @@ jobs:
       [test, pre-commit, build]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      tag_name: ${{ steps.get_tag.outputs.git_tag }}
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -90,15 +93,12 @@ jobs:
         with:
           name: release-artifacts-${{ matrix.os }}
           path: release-artifacts
-      - name: Get the tag
-        id: get_tag
-        run: echo ::set-output name=git_tag::${GITHUB_REF/refs\/tags\//}
       - name: Upload Release Asset - ${{ matrix.os }}
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./release-artifacts/kubent-${{ steps.get_tag.outputs.git_tag }}-${{ matrix.os }}-amd64.tar.gz
-          asset_name: kubent-${{ steps.get_tag.outputs.git_tag }}-${{ matrix.os }}-amd64.tar.gz
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./release-artifacts/kubent-${{ needs.create-release.outputs.tag_name }}-${{ matrix.os }}-amd64.tar.gz
+          asset_name: kubent-${{ needs.create-release.outputs.tag_name }}-${{ matrix.os }}-amd64.tar.gz
           asset_content_type: application/tar+gzip


### PR DESCRIPTION
This should fix failing _Upload Release Asset_ steps (https://github.com/doitintl/kube-no-trouble/runs/2251044417?check_suite_focus=true):

```yaml
Run actions/upload-release-asset@v1
  with:
    asset_path: ./release-artifacts/kubent-nightly-0.3.2-98-ga011986-linux-amd64.tar.gz
    asset_name: kubent-nightly-0.3.2-98-ga011986-linux-amd64.tar.gz
    asset_content_type: application/tar+gzip
  env:
    GITHUB_TOKEN: ***
Error: Input required and not supplied: upload_url
```

 using the [jobs outputs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs).