### PR TITLE
Feat: Detect K8s version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,20 @@ Usage of ./kubent:
       --helm2                     enable Helm v2 collector (default true)
       --helm3                     enable Helm v3 collector (default true)
   -k, --kubeconfig string         path to the kubeconfig file (default "/Users/stepan/.kube/config")
-  -l, --loglevel string           set log level (trace, debug, info, warn, error, fatal, panic, disabled)
+  -l, --log-level string          set log level (trace, debug, info, warn, error, fatal, panic, disabled) (default "info")
   -o, --output string             output format - [text|json] (default "text")
+  -t, --target-version string     target K8s version in major.minor format (autodetected by default)
 ```
 
 - *`-a, --additional-kind`*
   Tells `kubent` to flag additional custom resources when found in the specified version. The flag can be used multiple
   times. The expected format is full *Kind.version.group.com* form - e.g. `-a ManagedCertificate.v1.networking.gke.io`.
+
+- *`-t, --target-version`*
+  `Kubent` will try to detect K8S cluster version and display only relevant findings. This flag allows to override this
+  version for scenarios like use in CI with the file collector only, when detection from an actual cluster is not possible.
+  Expected format is `major.minor[.patch]`, e.g. `1.16` or `1.16.3`.
+
 
 ### Use in CI
 

--- a/cmd/kubent/main_test.go
+++ b/cmd/kubent/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/doitintl/kube-no-trouble/pkg/collector"
 	"github.com/doitintl/kube-no-trouble/pkg/config"
+
 	"github.com/rs/zerolog"
 )
 
@@ -139,5 +140,54 @@ func TestMainExitCodes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGetServerVersionNone(t *testing.T) {
+	collectors := []collector.Collector{}
+
+	version, err := getServerVersion(collectors)
+	if err != nil {
+		t.Errorf("Failed to get version with error: %s", err)
+	}
+
+	if version != "" {
+		t.Errorf("Expected no version to be detected, instead got: %s", version)
+	}
+}
+
+func TestGetServerVersionNotSupported(t *testing.T) {
+	collectors := []collector.Collector{}
+
+	fileCollector, err := collector.NewFileCollector(&collector.FileOpts{Filenames: []string{"../../fixtures/deployment-v1beta1.yaml"}})
+	if err != nil {
+		t.Errorf("Failed to create File collector with error: %s", err)
+	}
+
+	collectors = storeCollector(fileCollector, err, collectors)
+
+	version, err := getServerVersion(collectors)
+	if err != nil {
+		t.Errorf("Failed to get version with error: %s", err)
+	}
+
+	if version != "" {
+		t.Errorf("Expected no version to be detected, instead got: %s", version)
+	}
+}
+
+func TestGetServerVersion(t *testing.T) {
+	collectors := []collector.Collector{}
+
+	fc := collector.NewFakeCollector()
+	collectors = storeCollector(fc, nil, collectors)
+
+	version, err := getServerVersion(collectors)
+	if err != nil {
+		t.Errorf("Failed to get version with error: %s", err)
+	}
+
+	if version != collector.FAKE_VERSION {
+		t.Errorf("Expected no version to be detected, instead got: %s", version)
 	}
 }

--- a/pkg/collector/cluster_test.go
+++ b/pkg/collector/cluster_test.go
@@ -50,7 +50,7 @@ func TestNewClusterCollectorFakeClient(t *testing.T) {
 
 	collector, err := NewClusterCollector(&testOpts, []string{})
 	if err != nil {
-		t.Errorf("failed to create cluster collector from fake client: %s", err)
+		t.Fatalf("failed to create cluster collector from fake client: %s", err)
 	}
 
 	result, err := collector.Get()

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -5,8 +5,18 @@ type Collector interface {
 	Name() string
 }
 
+type VersionCollector interface {
+	GetServerVersion() (string, error)
+}
+
 type commonCollector struct {
 	name string
+}
+
+func newCommonCollector(name string) *commonCollector {
+	return &commonCollector{
+		name: name,
+	}
 }
 
 func (c *commonCollector) Name() string {

--- a/pkg/collector/fake.go
+++ b/pkg/collector/fake.go
@@ -1,0 +1,21 @@
+package collector
+
+const FAKE_VERSION = "1.2.3"
+
+type fakeCollector struct {
+	*commonCollector
+}
+
+func (c *fakeCollector) Get() ([]map[string]interface{}, error) {
+	return []map[string]interface{}{}, nil
+}
+
+func NewFakeCollector() *fakeCollector {
+	return &fakeCollector{
+		commonCollector: newCommonCollector("Fake"),
+	}
+}
+
+func (c *fakeCollector) GetServerVersion() (string, error) {
+	return FAKE_VERSION, nil
+}

--- a/pkg/collector/file.go
+++ b/pkg/collector/file.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ghodss/yaml"
-	"helm.sh/helm/v3/pkg/releaseutil"
 	"io/ioutil"
 	"os"
 	"sort"
+
+	"github.com/ghodss/yaml"
+	"helm.sh/helm/v3/pkg/releaseutil"
 )
 
 type FileCollector struct {
@@ -27,7 +28,7 @@ func NewFileCollector(opts *FileOpts) (*FileCollector, error) {
 	}
 
 	collector := &FileCollector{
-		commonCollector: &commonCollector{name: "File"},
+		commonCollector: newCommonCollector("File"),
 		filenames:       opts.Filenames,
 	}
 

--- a/pkg/collector/kube.go
+++ b/pkg/collector/kube.go
@@ -1,0 +1,39 @@
+package collector
+
+import (
+	"fmt"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type kubeCollector struct {
+	discoveryClient discovery.DiscoveryInterface
+}
+
+func newKubeCollector(kubeconfig string, discoveryClient discovery.DiscoveryInterface) (*kubeCollector, error) {
+	col := &kubeCollector{}
+
+	if discoveryClient == nil {
+		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+
+		col.discoveryClient, err = discovery.NewDiscoveryClientForConfig(config)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		col.discoveryClient = discoveryClient
+	}
+
+	return col, nil
+}
+
+func (c *kubeCollector) GetServerVersion() (string, error) {
+	version, err := c.discoveryClient.ServerVersion()
+	if err != nil {
+		return "", fmt.Errorf("failed to get server version %w", err)
+	}
+	return version.Major + "." + version.Minor, nil
+}

--- a/pkg/collector/kube_test.go
+++ b/pkg/collector/kube_test.go
@@ -1,0 +1,56 @@
+package collector
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+	discoveryFake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNewKubeCollector(t *testing.T) {
+	clientSet := fake.NewSimpleClientset()
+	col, err := newKubeCollector("", clientSet.Discovery())
+
+	if err != nil {
+		t.Errorf("Failed to create kubeCollector form fake discovery client")
+	}
+	if col == nil {
+		t.Errorf("Should return collector, instrad got nil")
+	}
+
+}
+
+func TestNewKubeCollectorError(t *testing.T) {
+	_, err := newKubeCollector("does-not-exist", nil)
+
+	if err == nil {
+		t.Errorf("Expected to fail with non-existent kubeconfig")
+	}
+}
+
+func TestGetServerVersion(t *testing.T) {
+	expectedMajor := "1"
+	expectedMinor := "2"
+	expectedVersion := expectedMajor + "." + expectedMinor
+
+	clientSet := fake.NewSimpleClientset()
+	clientSet.Discovery().(*discoveryFake.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major: expectedMajor,
+		Minor: expectedMinor,
+	}
+
+	collector, err := newKubeCollector("", clientSet.Discovery())
+	if err != nil {
+		t.Fatalf("failed to create kubeCollector from fake client: %s", err)
+	}
+
+	version, err := collector.GetServerVersion()
+	if err != nil {
+		t.Errorf("Failed to get version with error: %s", err)
+	}
+
+	if version != expectedVersion {
+		t.Errorf("Expected no version to be detected, instead got: %s", version)
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -152,3 +152,28 @@ func TestValidateAdditionalResourcesFail(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateTargetVersion(t *testing.T) {
+	validVersions := []string{
+		"", "1.16", "1.16.3", "1.2.3",
+	}
+	invalidVersions := []string{
+		"1", "v12.3.4", "v1.2", "1.blah", "nope",
+	}
+
+	for _, v := range validVersions {
+		err := validateTargetVersion(v)
+
+		if err != nil {
+			t.Errorf("Expected %s to fail validation, it failed instead with: %s", v, err)
+		}
+	}
+
+	for _, v := range invalidVersions {
+		err := validateTargetVersion(v)
+
+		if err == nil {
+			t.Errorf("Expected %s to fail validation, it succeeded instead", v)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support for detecting version of K8s server. It's a foundation for being able to filter relevant findings later on.

From #130:
- [x] Only detect version if one of the relevant collectors (cluster, Helm v2/3) is enabled (I'm thinking about extending the collector interface here)
- [x] Allow version override via flag - for cases when this is used with files in CI

WIP, apart from above it's missing:
- [x] Update docs once flag to override version is added
- [x] Tests
- [x] Maybe reduce code duplication - in particular `GetServerVersion` and discovery K8s client creation in `New*Collector` functions (without introducing to much complexity via embedding).
- [x] Needs squash/commits cleanup before merge (please!)


This PR addresses first half of #130.