### PR TITLE
ci: Correct reference to non-existing build artifact

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: release-artifacts-linux
+          name: release-artifacts-linux-amd64
           path: release-artifacts
       - name: Get the tag
         id: get_tag


### PR DESCRIPTION
This should fix issue where the build is referencing non-existing artifact  - https://github.com/doitintl/kube-no-trouble/runs/2626121412?check_suite_focus=true