### PR TITLE
test: Fix slow TestNewClusterCollectorValidEmptyCollector

### DIFF
--- a/pkg/collector/cluster_test.go
+++ b/pkg/collector/cluster_test.go
@@ -28,7 +28,14 @@ func TestNewClusterCollectorBadPath(t *testing.T) {
 }
 
 func TestNewClusterCollectorValidEmptyCollector(t *testing.T) {
-	testOpts := ClusterOpts{Kubeconfig: "../../fixtures/kube.config"}
+	scheme := runtime.NewScheme()
+	clientset := fake.NewSimpleDynamicClient(scheme)
+	discoveryClient := discoveryFake.FakeDiscovery{}
+	testOpts := ClusterOpts{
+		Kubeconfig:      "../../fixtures/kube.config",
+		ClientSet:       clientset,
+		DiscoveryClient: &discoveryClient,
+	}
 	collector, err := NewClusterCollector(&testOpts, []string{})
 
 	if err != nil {


### PR DESCRIPTION
We can use fake client in this test, avoiding waiting for timeouts.

original:
```
=== RUN   TestNewClusterCollectorValidEmptyCollector
--- PASS: TestNewClusterCollectorValidEmptyCollector (330.04s)
```

new:
```
=== RUN   TestNewClusterCollectorValidEmptyCollector
--- PASS: TestNewClusterCollectorValidEmptyCollector (0.00s)
```

Closes #155