### PR TITLE
feat: Cover deprecated `scheduling.k8s.io/v1beta1` - PriorityClass resource

### DIFF
--- a/fixtures/priorityclass-v1beta1.yaml
+++ b/fixtures/priorityclass-v1beta1.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PriorityClass
+metadata:
+  name: default
+value: 100
+globalDefault: true
+description: "Default priority class"

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -82,6 +82,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csinodes"},
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"},
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "volumeattachments"},
+		schema.GroupVersionResource{Group: "scheduling.k8s.io/v1", Version: "v1", Resource: "priorityclasses"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -46,6 +46,11 @@ deprecated_api(kind, api_version) = api {
 			"new": "coordination.k8s.io/v1",
 			"since": "1.19",
 		},
+		"PriorityClass": {
+			"old": ["scheduling.k8s.io/v1beta1"],
+			"new": "scheduling.k8s.io/v1",
+			"since": "1.14",
+		},
 		"CSIDriver": {
 			"old": ["storage.k8s.io/v1beta1"],
 			"new": "storage.k8s.io/v1",

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -16,6 +16,7 @@ func TestRego116(t *testing.T) {
 		{"CSINode", []string{"../fixtures/csinode-v1beta1.yaml"}, []string{"CSINode"}},
 		{"StorageClass", []string{"../fixtures/storageclass-v1beta1.yaml"}, []string{"StorageClass"}},
 		{"VolumeAttachment", []string{"../fixtures/volumeattachment-v1beta1.yaml"}, []string{"VolumeAttachment"}},
+		{"PriorityClass", []string{"../fixtures/priorityclass-v1beta1.yaml"}, []string{"PriorityClass"}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Cover deprecated `scheduling.k8s.io/v1beta1` - PriorityClass resource

As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/ add PriorityClass resource.

Review after #156, it will be easier :)
Part of #135