### PR TITLE
feat: Cover deprecated `rbac.authorization.k8s.io/v1beta1` - RBAC resources

### DIFF
--- a/fixtures/clusterrole-v1beta1.yaml
+++ b/fixtures/clusterrole-v1beta1.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: pod-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]

--- a/fixtures/clusterrolebinding-v1beta1.yaml
+++ b/fixtures/clusterrolebinding-v1beta1.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: read-pods
+subjects:
+- kind: User
+  name: jane
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/fixtures/role-v1beta1.yaml
+++ b/fixtures/role-v1beta1.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: default
+  name: pod-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]

--- a/fixtures/rolebinding-v1beta1.yaml
+++ b/fixtures/rolebinding-v1beta1.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: read-pods
+  namespace: default
+subjects:
+- kind: User
+  name: jane
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -83,6 +83,10 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"},
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "volumeattachments"},
 		schema.GroupVersionResource{Group: "scheduling.k8s.io/v1", Version: "v1", Resource: "priorityclasses"},
+		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"},
+		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"},
+		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"},
+		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -71,6 +71,26 @@ deprecated_api(kind, api_version) = api {
 			"new": "storage.k8s.io/v1",
 			"since": "1.13",
 		},
+		"ClusterRole": {
+			"old": ["rbac.authorization.k8s.io/v1beta1"],
+			"new": "rbac.authorization.k8s.io/v1",
+			"since": "1.8",
+		},
+		"ClusterRoleBinding": {
+			"old": ["rbac.authorization.k8s.io/v1beta1"],
+			"new": "rbac.authorization.k8s.io/v1",
+			"since": "1.8",
+		},
+		"Role": {
+			"old": ["rbac.authorization.k8s.io/v1beta1"],
+			"new": "rbac.authorization.k8s.io/v1",
+			"since": "1.8",
+		},
+		"RoleBinding": {
+			"old": ["rbac.authorization.k8s.io/v1beta1"],
+			"new": "rbac.authorization.k8s.io/v1",
+			"since": "1.8",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/doitintl/kube-no-trouble/pkg/collector"
 )
 
-func TestRego116(t *testing.T) {
+func TestRego122(t *testing.T) {
 	testCases := []struct {
 		name          string
 		manifests     []string
@@ -16,8 +16,8 @@ func TestRego116(t *testing.T) {
 		{"ClusterRoleBinding", []string{"../fixtures/clusterrolebinding-v1beta1.yaml"}, []string{"ClusterRoleBinding"}},
 		{"CSIDriver", []string{"../fixtures/csidriver-v1beta1.yaml"}, []string{"CSIDriver"}},
 		{"CSINode", []string{"../fixtures/csinode-v1beta1.yaml"}, []string{"CSINode"}},
-		{"Role", []string{"../fixtures/role-v1beta1.yaml"}, []string{"ClusterRole"}},
-		{"RoleBinding", []string{"../fixtures/rolebinding-v1beta1.yaml"}, []string{"ClusterRoleBinding"}},
+		{"Role", []string{"../fixtures/role-v1beta1.yaml"}, []string{"Role"}},
+		{"RoleBinding", []string{"../fixtures/rolebinding-v1beta1.yaml"}, []string{"RoleBinding"}},
 		{"StorageClass", []string{"../fixtures/storageclass-v1beta1.yaml"}, []string{"StorageClass"}},
 		{"VolumeAttachment", []string{"../fixtures/volumeattachment-v1beta1.yaml"}, []string{"VolumeAttachment"}},
 		{"PriorityClass", []string{"../fixtures/priorityclass-v1beta1.yaml"}, []string{"PriorityClass"}},

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -12,8 +12,12 @@ func TestRego116(t *testing.T) {
 		manifests     []string
 		expectedKinds []string // kinds of objects
 	}{
+		{"ClusterRole", []string{"../fixtures/clusterrole-v1beta1.yaml"}, []string{"ClusterRole"}},
+		{"ClusterRoleBinding", []string{"../fixtures/clusterrolebinding-v1beta1.yaml"}, []string{"ClusterRoleBinding"}},
 		{"CSIDriver", []string{"../fixtures/csidriver-v1beta1.yaml"}, []string{"CSIDriver"}},
 		{"CSINode", []string{"../fixtures/csinode-v1beta1.yaml"}, []string{"CSINode"}},
+		{"Role", []string{"../fixtures/role-v1beta1.yaml"}, []string{"ClusterRole"}},
+		{"RoleBinding", []string{"../fixtures/rolebinding-v1beta1.yaml"}, []string{"ClusterRoleBinding"}},
 		{"StorageClass", []string{"../fixtures/storageclass-v1beta1.yaml"}, []string{"StorageClass"}},
 		{"VolumeAttachment", []string{"../fixtures/volumeattachment-v1beta1.yaml"}, []string{"VolumeAttachment"}},
 		{"PriorityClass", []string{"../fixtures/priorityclass-v1beta1.yaml"}, []string{"PriorityClass"}},


### PR DESCRIPTION
Cover deprecated `rbac.authorization.k8s.io/v1beta1` - RBAC resources

As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/ add `rbac.authorization.k8s.io/v1beta1` group of resources.

Review after #156, it will be easier :)
Part of #135