### PR TITLE
feat: Cover deprecated `networking.k8s.io/v1beta1` - Ingress* resources

### DIFF
--- a/fixtures/ingressclass-v1beta1.yaml
+++ b/fixtures/ingressclass-v1beta1.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
+  name: external-lb
+spec:
+  controller: example.com/ingress-controller
+  parameters:
+    apiGroup: k8s.example.com
+    kind: IngressParameters
+    name: external-lb

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -78,6 +78,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
 		schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"},
 		schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "ingresses"},
+		schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingressclasses"},
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csidrivers"},
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csinodes"},
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"},

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -22,9 +22,14 @@ deprecated_resource(r) = api {
 deprecated_api(kind, api_version) = api {
 	deprecated_apis = {
 		"Ingress": {
-			"old": ["extensions/v1beta1"],
-			"new": "networking.k8s.io/v1beta1",
-			"since": "1.14",
+			"old": ["extensions/v1beta1", "networking.k8s.io/v1beta1"],
+			"new": "networking.k8s.io/v1",
+			"since": "1.19",
+		},
+		"IngressClass": {
+			"old": ["networking.k8s.io/v1beta1"],
+			"new": "networking.k8s.io/v1",
+			"since": "1.19",
 		},
 		"TokenReview": {
 			"old": ["authentication.k8s.io/v1beta1"],

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -21,6 +21,8 @@ func TestRego122(t *testing.T) {
 		{"StorageClass", []string{"../fixtures/storageclass-v1beta1.yaml"}, []string{"StorageClass"}},
 		{"VolumeAttachment", []string{"../fixtures/volumeattachment-v1beta1.yaml"}, []string{"VolumeAttachment"}},
 		{"PriorityClass", []string{"../fixtures/priorityclass-v1beta1.yaml"}, []string{"PriorityClass"}},
+		{"Ingress", []string{"../fixtures/ingress-v1beta1.yaml"}, []string{"Ingress"}},
+		{"IngressClass", []string{"../fixtures/ingressclass-v1beta1.yaml"}, []string{"IngressClass"}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Cover deprecated `networking.k8s.io/v1beta1` - Ingress* resources

As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/, add `networking.k8s.io/v1beta1` group of resources.

Part of #135
Fixes #94