### PR TITLE
fix: Remove `LeaseList` and add `Lease` to cluster collector, add test for `Lease`

### DIFF
--- a/fixtures/lease-v1beta1.yaml
+++ b/fixtures/lease-v1beta1.yaml
@@ -1,0 +1,9 @@
+apiVersion: coordination.k8s.io/v1beta1
+kind: Lease
+metadata:
+  name: example
+  namespace: default
+spec:
+  holderIdentity: "12"
+  leaseDurationSeconds: 60
+  leaseTransitions: 123

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -88,6 +88,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"},
 		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"},
 		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
+		schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1", Resource: "leases"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -44,12 +44,7 @@ deprecated_api(kind, api_version) = api {
 		"Lease": {
 			"old": ["coordination.k8s.io/v1beta1"],
 			"new": "coordination.k8s.io/v1",
-			"since": "1.19",
-		},
-		"LeaseList": {
-			"old": ["coordination.k8s.io/v1beta1"],
-			"new": "coordination.k8s.io/v1",
-			"since": "1.19",
+			"since": "1.14",
 		},
 		"PriorityClass": {
 			"old": ["scheduling.k8s.io/v1beta1"],

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -23,6 +23,7 @@ func TestRego122(t *testing.T) {
 		{"PriorityClass", []string{"../fixtures/priorityclass-v1beta1.yaml"}, []string{"PriorityClass"}},
 		{"Ingress", []string{"../fixtures/ingress-v1beta1.yaml"}, []string{"Ingress"}},
 		{"IngressClass", []string{"../fixtures/ingressclass-v1beta1.yaml"}, []string{"IngressClass"}},
+		{"Lease", []string{"../fixtures/lease-v1beta1.yaml"}, []string{"Lease"}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR is about minor fixes and adding test for `coordination.k8s.io/v1beta1` API group.

Changes:
- fix: Add Leases to be pulled by cluster collector
- fix: Remove LeaseList from rules
- test: Add test for Lease

#135, #113 