### PR TITLE
feat: Cover deprecated `certificates.k8s.io/v1beta1` API group

### DIFF
--- a/fixtures/certificatesigningrequest-v1beta1.yaml
+++ b/fixtures/certificatesigningrequest-v1beta1.yaml
@@ -1,0 +1,9 @@
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: example.com
+spec:
+  request: aGVsbG9YWAo=
+  usages:
+  - key encipherment
+  - server auth

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -89,6 +89,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"},
 		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
 		schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1", Resource: "leases"},
+		schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1beta1", Resource: "certificatesigningrequests"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -91,6 +91,11 @@ deprecated_api(kind, api_version) = api {
 			"new": "rbac.authorization.k8s.io/v1",
 			"since": "1.8",
 		},
+		"CertificateSigningRequest": {
+			"old": ["certificates.k8s.io/v1beta1"],
+			"new": "certificates.k8s.io/v1",
+			"since": "1.19",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -24,6 +24,7 @@ func TestRego122(t *testing.T) {
 		{"Ingress", []string{"../fixtures/ingress-v1beta1.yaml"}, []string{"Ingress"}},
 		{"IngressClass", []string{"../fixtures/ingressclass-v1beta1.yaml"}, []string{"IngressClass"}},
 		{"Lease", []string{"../fixtures/lease-v1beta1.yaml"}, []string{"Lease"}},
+		{"CertificateSigningRequest", []string{"../fixtures/certificatesigningrequest-v1beta1.yaml"}, []string{"CertificateSigningRequest"}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR adds coverage of deprecated certificates.k8s.io/v1beta1 API group

As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/,
add `certificates.k8s.io/v1beta1` group of resources.

Part of #135