### PR TITLE
feat: Cover deprecated `auth*.k8s.io/v1beta1` API groups

### DIFF
--- a/fixtures/localsubjectaccessreview-v1beta1.yaml
+++ b/fixtures/localsubjectaccessreview-v1beta1.yaml
@@ -1,0 +1,9 @@
+apiVersion: authorization.k8s.io/v1beta1
+kind: LocalSubjectAccessReview
+spec:
+  resourceAttributes:
+    group: apps
+    resource: deployments
+    verb: create
+  user: jane
+  groups: ["system:authenticated"]

--- a/fixtures/selfsubjectaccessreview-v1beta1.yaml
+++ b/fixtures/selfsubjectaccessreview-v1beta1.yaml
@@ -1,0 +1,8 @@
+apiVersion: authorization.k8s.io/v1beta1
+kind: SelfSubjectAccessReview
+spec:
+  resourceAttributes:
+    group: apps
+    resource: deployments
+    namespace: dev
+    verb: create

--- a/fixtures/subjectaccessreview-v1beta1.yaml
+++ b/fixtures/subjectaccessreview-v1beta1.yaml
@@ -1,0 +1,10 @@
+apiVersion: authorization.k8s.io/v1beta1
+kind: SubjectAccessReview
+spec:
+  resourceAttributes:
+    group: apps
+    resource: deployments
+    namespace: dev
+    verb: create
+  user: jane
+  groups: ["system:authenticated"]

--- a/fixtures/tokenreview-v1beta1.yaml
+++ b/fixtures/tokenreview-v1beta1.yaml
@@ -1,0 +1,5 @@
+apiVersion: authentication.k8s.io/v1beta1
+kind: TokenReview
+spec:
+  token: "014fbff9a07c..."
+  audiences: ["https://myserver.example.com", "https://myserver.internal.example.com"]

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -90,6 +90,10 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
 		schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1", Resource: "leases"},
 		schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1beta1", Resource: "certificatesigningrequests"},
+		schema.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1", Resource: "subjectaccessreviews"},
+		schema.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1", Resource: "selfsubjectaccessreviews"},
+		schema.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1", Resource: "localsubjectaccessreviews"},
+		schema.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1", Resource: "tokenreviews"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -41,6 +41,16 @@ deprecated_api(kind, api_version) = api {
 			"new": "authorization.k8s.io/v1",
 			"since": "1.19",
 		},
+		"SelfSubjectAccessReview": {
+			"old": ["authorization.k8s.io/v1beta1"],
+			"new": "authorization.k8s.io/v1",
+			"since": "1.19",
+		},
+		"LocalSubjectAccessReview": {
+			"old": ["authorization.k8s.io/v1beta1"],
+			"new": "authorization.k8s.io/v1",
+			"since": "1.19",
+		},
 		"Lease": {
 			"old": ["coordination.k8s.io/v1beta1"],
 			"new": "coordination.k8s.io/v1",

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -25,6 +25,10 @@ func TestRego122(t *testing.T) {
 		{"IngressClass", []string{"../fixtures/ingressclass-v1beta1.yaml"}, []string{"IngressClass"}},
 		{"Lease", []string{"../fixtures/lease-v1beta1.yaml"}, []string{"Lease"}},
 		{"CertificateSigningRequest", []string{"../fixtures/certificatesigningrequest-v1beta1.yaml"}, []string{"CertificateSigningRequest"}},
+		{"SubjectAccessReview", []string{"../fixtures/subjectaccessreview-v1beta1.yaml"}, []string{"SubjectAccessReview"}},
+		{"SelfSubjectAccessReview", []string{"../fixtures/selfsubjectaccessreview-v1beta1.yaml"}, []string{"SelfSubjectAccessReview"}},
+		{"LocalSubjectAccessReview", []string{"../fixtures/localsubjectaccessreview-v1beta1.yaml"}, []string{"LocalSubjectAccessReview"}},
+		{"TokenReview", []string{"../fixtures/tokenreview-v1beta1.yaml"}, []string{"TokenReview"}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR adds coverage of deprecated  `authorization.k8s.io/v1beta1` and `authentication.k8s.io/v1beta1` API groups

- SelfSubjectAccessReview, LocalSubjectAccessReview, SubjectAccessReview
- TokenReview resources.

Part of #135