### PR TITLE
feat: Cover deprecated `apiregistration.k8s.io/v1beta1` API group

### DIFF
--- a/fixtures/apiservice-v1beta1.yaml
+++ b/fixtures/apiservice-v1beta1.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.wardle.example.com
+spec:
+  insecureSkipTLSVerify: true
+  group: wardle.example.com
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: api
+    namespace: wardle
+  version: v1alpha1

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -94,6 +94,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1", Resource: "localsubjectaccessreviews"},
 		schema.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1", Resource: "tokenreviews"},
 		schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"},
+		schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -106,6 +106,11 @@ deprecated_api(kind, api_version) = api {
 			"new": "certificates.k8s.io/v1",
 			"since": "1.19",
 		},
+		"APIService": {
+			"old": ["apiregistration.k8s.io/v1beta1"],
+			"new": "apiregistration.k8s.io/v1",
+			"since": "1.10",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -29,6 +29,7 @@ func TestRego122(t *testing.T) {
 		{"SelfSubjectAccessReview", []string{"../fixtures/selfsubjectaccessreview-v1beta1.yaml"}, []string{"SelfSubjectAccessReview"}},
 		{"LocalSubjectAccessReview", []string{"../fixtures/localsubjectaccessreview-v1beta1.yaml"}, []string{"LocalSubjectAccessReview"}},
 		{"TokenReview", []string{"../fixtures/tokenreview-v1beta1.yaml"}, []string{"TokenReview"}},
+		{"APIService", []string{"../fixtures/apiservice-v1beta1.yaml"}, []string{"APIService"}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR adds coverage of deprecated `apiregistration.k8s.io/v1beta1` API group - `APIService` resource.

Part of #135