### PR TITLE
feat: Cover deprecated `apiextensions.k8s.io/v1beta1` API group

### DIFF
--- a/fixtures/customresourcedefinition-v1beta1.yaml
+++ b/fixtures/customresourcedefinition-v1beta1.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+        name: certificates.test.k8s.io
+spec:
+  group: test.k8s.io
+  version: v1beta1
+  scope: Cluster
+  names:
+    plural: certificates
+    singular: certificate
+    kind: Certificate
+    categories:
+      - all
+  additionalPrinterColumns:
+    - name: Status
+      type: string
+      JSONPath: .status.lastConditionState
+  subresources:
+    status: {}

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -95,6 +95,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1", Resource: "tokenreviews"},
 		schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"},
 		schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"},
+		schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -111,6 +111,11 @@ deprecated_api(kind, api_version) = api {
 			"new": "apiregistration.k8s.io/v1",
 			"since": "1.10",
 		},
+		"CustomResourceDefinition": {
+			"old": ["apiextensions.k8s.io/v1beta1"],
+			"new": "apiextensions.k8s.io/v1",
+			"since": "1.16",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -30,6 +30,7 @@ func TestRego122(t *testing.T) {
 		{"LocalSubjectAccessReview", []string{"../fixtures/localsubjectaccessreview-v1beta1.yaml"}, []string{"LocalSubjectAccessReview"}},
 		{"TokenReview", []string{"../fixtures/tokenreview-v1beta1.yaml"}, []string{"TokenReview"}},
 		{"APIService", []string{"../fixtures/apiservice-v1beta1.yaml"}, []string{"APIService"}},
+		{"CustomResourceDefinition", []string{"../fixtures/customresourcedefinition-v1beta1.yaml"}, []string{"CustomResourceDefinition"}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR adds coverage for deprecated `apiextensions.k8s.io/v1beta1` API group - `CustomResourceDefinition` resource.

Part of #135