### PR TITLE
feat: Cover deprecated `admissionregistration.k8s.io/v1beta1` API group

### DIFF
--- a/fixtures/mutatingwebhookconfiguration-v1beta1.yaml
+++ b/fixtures/mutatingwebhookconfiguration-v1beta1.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: test
+  namespace: my-namespace
+webhooks:
+  - name: test.example.com
+    clientConfig:
+      service:
+        name: webhook
+        namespace: test
+        path: "/"
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]

--- a/fixtures/validatingwebhookconfiguration-v1beta1.yaml
+++ b/fixtures/validatingwebhookconfiguration-v1beta1.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: test
+  namespace: my-namespace
+webhooks:
+  - name: test.example.com
+    clientConfig:
+      service:
+        name: webhook
+        namespace: test
+        path: "/"
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -96,6 +96,8 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"},
 		schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"},
 		schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"},
+		schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingwebhookconfigurations"},
+		schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -116,6 +116,16 @@ deprecated_api(kind, api_version) = api {
 			"new": "apiextensions.k8s.io/v1",
 			"since": "1.16",
 		},
+		"MutatingWebhookConfiguration": {
+			"old": ["admissionregistration.k8s.io/v1beta1"],
+			"new": "admissionregistration.k8s.io/v1",
+			"since": "1.16",
+		},
+		"ValidatingWebhookConfiguration": {
+			"old": ["admissionregistration.k8s.io/v1beta1"],
+			"new": "admissionregistration.k8s.io/v1",
+			"since": "1.16",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -31,6 +31,8 @@ func TestRego122(t *testing.T) {
 		{"TokenReview", []string{"../fixtures/tokenreview-v1beta1.yaml"}, []string{"TokenReview"}},
 		{"APIService", []string{"../fixtures/apiservice-v1beta1.yaml"}, []string{"APIService"}},
 		{"CustomResourceDefinition", []string{"../fixtures/customresourcedefinition-v1beta1.yaml"}, []string{"CustomResourceDefinition"}},
+		{"MutatingWebhookConfiguration", []string{"../fixtures/mutatingwebhookconfiguration-v1beta1.yaml"}, []string{"MutatingWebhookConfiguration"}},
+		{"ValidatingWebhookConfiguration", []string{"../fixtures/validatingwebhookconfiguration-v1beta1.yaml"}, []string{"ValidatingWebhookConfiguration"}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR adds coverage for the deprecated `admissionregistration.k8s.io/v1beta1` API group

As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/
add admissionregistration.k8s.io/v1beta1 group of resources:
- `MutatingWebhookConfiguration`
- `ValidatingWebhookConfiguration`

Part of #135