### PR TITLE
feat: Cover deprecated `policy/v1beta1` API group - PodDisruptionBudget

### DIFF
--- a/fixtures/poddisruptionbudget-v1beta1.yaml
+++ b/fixtures/poddisruptionbudget-v1beta1.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: xy-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: xy

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -99,6 +99,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingwebhookconfigurations"},
 		schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations"},
 		schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasses"},
+		schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-25.rego
+++ b/pkg/rules/rego/deprecated-1-25.rego
@@ -20,11 +20,18 @@ deprecated_resource(r) = api {
 }
 
 deprecated_api(kind, api_version) = api {
-	deprecated_apis = {"RuntimeClass": {
-		"old": ["node.k8s.io/v1beta1"],
-		"new": "node.k8s.io/v1",
-		"since": "1.20",
-	}}
+	deprecated_apis = {
+		"RuntimeClass": {
+			"old": ["node.k8s.io/v1beta1"],
+			"new": "node.k8s.io/v1",
+			"since": "1.20",
+		},
+		"PodDisruptionBudget": {
+			"old": ["policy/v1beta1"],
+			"new": "policy/v1",
+			"since": "1.21",
+		},
+	}
 
 	deprecated_apis[kind].old[_] == api_version
 

--- a/test/rules_125_test.go
+++ b/test/rules_125_test.go
@@ -7,6 +7,7 @@ import (
 func TestRego125(t *testing.T) {
 	testCases := []resourceFixtureTestCase{
 		{"RuntimeClass", []string{"../fixtures/runtimeclass-v1beta1.yaml"}, []string{"RuntimeClass"}},
+		{"PodDisruptionBudget", []string{"../fixtures/poddisruptionbudget-v1beta1.yaml"}, []string{"PodDisruptionBudget"}},
 	}
 
 	testReourcesUsingFixtures(t, testCases)


### PR DESCRIPTION
Cover deprecated policy/v1beta1 API group - PDB

As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/
add `policy/v1beta1` group - `PodDisruptionBudget` resource.

Part of #135
Easier to review after #171 