### PR TITLE
feat: Cover removed `policy/v1beta1` API group - PodSecurityPolicy

### DIFF
--- a/fixtures/podsecuritypolicy-v1beta1.yaml
+++ b/fixtures/podsecuritypolicy-v1beta1.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: example
+spec:
+  privileged: false
+  seLinux:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - '*'

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -100,6 +100,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations"},
 		schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasses"},
 		schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"},
+		schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-25.rego
+++ b/pkg/rules/rego/deprecated-1-25.rego
@@ -31,6 +31,11 @@ deprecated_api(kind, api_version) = api {
 			"new": "policy/v1",
 			"since": "1.21",
 		},
+		"PodSecurityPolicy": {
+			"old": ["policy/v1beta1"],
+			"new": "<removed>",
+			"since": "1.21",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version

--- a/test/rules_125_test.go
+++ b/test/rules_125_test.go
@@ -8,6 +8,7 @@ func TestRego125(t *testing.T) {
 	testCases := []resourceFixtureTestCase{
 		{"RuntimeClass", []string{"../fixtures/runtimeclass-v1beta1.yaml"}, []string{"RuntimeClass"}},
 		{"PodDisruptionBudget", []string{"../fixtures/poddisruptionbudget-v1beta1.yaml"}, []string{"PodDisruptionBudget"}},
+		{"PodSecurityPolicy", []string{"../fixtures/podsecuritypolicy-v1beta1.yaml"}, []string{"PodSecurityPolicy"}},
 	}
 
 	testReourcesUsingFixtures(t, testCases)


### PR DESCRIPTION
This PR adds coverage of removed `policy/v1beta1` API group - `PodSecurityPolicy` resource.

As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/
add `policy/v1beta1z group - zPodSecurityPolicy` resource.

Part of #135
Easier to review after #172 