### PR TITLE
feat: Cover deprecated `discovery.k8s.io/v1beta1` API group - EndpointSlice

### DIFF
--- a/fixtures/endpointslice-v1beta1.yaml
+++ b/fixtures/endpointslice-v1beta1.yaml
@@ -1,0 +1,20 @@
+apiVersion: discovery.k8s.io/v1beta1
+kind: EndpointSlice
+metadata:
+  name: example-abc
+  labels:
+    kubernetes.io/service-name: example
+addressType: IPv4
+ports:
+  - name: http
+    protocol: TCP
+    port: 80
+endpoints:
+  - addresses:
+      - "10.1.2.3"
+    conditions:
+      ready: true
+    hostname: pod-1
+    topology:
+      kubernetes.io/hostname: node-1
+      topology.kubernetes.io/zone: us-west2-a

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -101,6 +101,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasses"},
 		schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"},
 		schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"},
+		schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-25.rego
+++ b/pkg/rules/rego/deprecated-1-25.rego
@@ -36,6 +36,11 @@ deprecated_api(kind, api_version) = api {
 			"new": "<removed>",
 			"since": "1.21",
 		},
+		"EndpointSlice": {
+			"old": ["discovery.k8s.io/v1beta1"],
+			"new": "discovery.k8s.io/v1",
+			"since": "1.21",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version

--- a/test/rules_125_test.go
+++ b/test/rules_125_test.go
@@ -9,6 +9,7 @@ func TestRego125(t *testing.T) {
 		{"RuntimeClass", []string{"../fixtures/runtimeclass-v1beta1.yaml"}, []string{"RuntimeClass"}},
 		{"PodDisruptionBudget", []string{"../fixtures/poddisruptionbudget-v1beta1.yaml"}, []string{"PodDisruptionBudget"}},
 		{"PodSecurityPolicy", []string{"../fixtures/podsecuritypolicy-v1beta1.yaml"}, []string{"PodSecurityPolicy"}},
+		{"EndpointSlice", []string{"../fixtures/endpointslice-v1beta1.yaml"}, []string{"EndpointSlice"}},
 	}
 
 	testReourcesUsingFixtures(t, testCases)


### PR DESCRIPTION
This PR adds coverage of deprecated `discovery.k8s.io/v1beta1` API group - `EndpointSlice` resource.

As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/
add `discovery.k8s.io/v1beta1` group - `EndpointSlice` resource.

Part of #135
Easier to review after #171 