### PR TITLE
feat: Cover deprecated `batch/v1beta1` API group - CronJob

### DIFF
--- a/fixtures/cronjob-v1beta1.yaml
+++ b/fixtures/cronjob-v1beta1.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            imagePullPolicy: IfNotPresent
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -102,6 +102,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"},
 		schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"},
 		schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"},
+		schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-25.rego
+++ b/pkg/rules/rego/deprecated-1-25.rego
@@ -41,6 +41,11 @@ deprecated_api(kind, api_version) = api {
 			"new": "discovery.k8s.io/v1",
 			"since": "1.21",
 		},
+		"CronJobs": {
+			"old": ["batch/v1beta1"],
+			"new": "batch/v1",
+			"since": "1.21",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version

--- a/test/rules_125_test.go
+++ b/test/rules_125_test.go
@@ -10,6 +10,7 @@ func TestRego125(t *testing.T) {
 		{"PodDisruptionBudget", []string{"../fixtures/poddisruptionbudget-v1beta1.yaml"}, []string{"PodDisruptionBudget"}},
 		{"PodSecurityPolicy", []string{"../fixtures/podsecuritypolicy-v1beta1.yaml"}, []string{"PodSecurityPolicy"}},
 		{"EndpointSlice", []string{"../fixtures/endpointslice-v1beta1.yaml"}, []string{"EndpointSlice"}},
+		{"CronJob", []string{"../fixtures/cronjob-v1beta1.yaml"}, []string{"CronJob"}},
 	}
 
 	testReourcesUsingFixtures(t, testCases)


### PR DESCRIPTION
This PR adds coverage for deprecated `batch/v1beta1` API group - `CronJob` resource

As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/
add `batch/v1beta1` group - `CronJob` resource.

Part of #135
Easier to review once #172 is merged.