### PR TITLE
feat: Filter non-relevant results

### DIFF
--- a/cmd/kubent/main.go
+++ b/cmd/kubent/main.go
@@ -141,6 +141,11 @@ func main() {
 		log.Fatal().Err(err).Str("name", "Rego").Msg("Failed to evaluate input")
 	}
 
+	results, err = printer.FilterNonRelevantResults(results, config.TargetVersion.Version)
+	if err != nil {
+		log.Fatal().Err(err).Str("name", "Rego").Msg("Failed to filter results")
+	}
+
 	printer, err := printer.NewPrinter(config.Output)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create printer")

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/hashicorp/go-version v1.3.0
 	github.com/jmoiron/sqlx v1.2.0 // indirect
 	github.com/lib/pq v1.3.0 // indirect
 	github.com/open-policy-agent/opa v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -322,6 +322,8 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,12 +1,16 @@
 package collector
 
+import (
+	goversion "github.com/hashicorp/go-version"
+)
+
 type Collector interface {
 	Get() ([]map[string]interface{}, error)
 	Name() string
 }
 
 type VersionCollector interface {
-	GetServerVersion() (string, error)
+	GetServerVersion() (*goversion.Version, error)
 }
 
 type commonCollector struct {

--- a/pkg/collector/fake.go
+++ b/pkg/collector/fake.go
@@ -1,5 +1,9 @@
 package collector
 
+import (
+	goversion "github.com/hashicorp/go-version"
+)
+
 const FAKE_VERSION = "1.2.3"
 
 type fakeCollector struct {
@@ -16,6 +20,8 @@ func NewFakeCollector() *fakeCollector {
 	}
 }
 
-func (c *fakeCollector) GetServerVersion() (string, error) {
-	return FAKE_VERSION, nil
+func (c *fakeCollector) GetServerVersion() (*goversion.Version, error) {
+	version, err := goversion.NewVersion(FAKE_VERSION)
+
+	return version, err
 }

--- a/pkg/collector/kube.go
+++ b/pkg/collector/kube.go
@@ -2,6 +2,8 @@ package collector
 
 import (
 	"fmt"
+
+	goversion "github.com/hashicorp/go-version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -30,10 +32,11 @@ func newKubeCollector(kubeconfig string, discoveryClient discovery.DiscoveryInte
 	return col, nil
 }
 
-func (c *kubeCollector) GetServerVersion() (string, error) {
+func (c *kubeCollector) GetServerVersion() (*goversion.Version, error) {
 	version, err := c.discoveryClient.ServerVersion()
 	if err != nil {
-		return "", fmt.Errorf("failed to get server version %w", err)
+		return nil, fmt.Errorf("failed to get server version %w", err)
 	}
-	return version.Major + "." + version.Minor, nil
+
+	return goversion.NewVersion(version.String())
 }

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	goversion "github.com/hashicorp/go-version"
+)
+
+type Version struct {
+	*goversion.Version
+}
+
+func (v *Version) String() string {
+	if v.Version != nil {
+		return v.Version.String()
+	}
+	return ""
+}
+
+func (v *Version) Set(s string) error {
+	version, err := goversion.NewVersion(s)
+	if err != nil {
+		return err
+	}
+	v.Version = version
+	return nil
+}
+
+func (v *Version) SetFromVersion(new *goversion.Version) error {
+	v.Version = new
+	return nil
+}
+
+func (v *Version) Type() string {
+	return "string"
+}
+
+func NewVersion() *Version {
+	return &Version{}
+}

--- a/pkg/judge/judge.go
+++ b/pkg/judge/judge.go
@@ -1,5 +1,9 @@
 package judge
 
+import (
+	goversion "github.com/hashicorp/go-version"
+)
+
 type Result struct {
 	Name        string
 	Namespace   string
@@ -7,7 +11,7 @@ type Result struct {
 	ApiVersion  string
 	RuleSet     string
 	ReplaceWith string
-	Since       string
+	Since       *goversion.Version
 }
 
 type Judge interface {

--- a/pkg/judge/rego.go
+++ b/pkg/judge/rego.go
@@ -2,6 +2,7 @@ package judge
 
 import (
 	"context"
+	goversion "github.com/hashicorp/go-version"
 
 	"github.com/doitintl/kube-no-trouble/pkg/rules"
 	"github.com/open-policy-agent/opa/rego"
@@ -50,6 +51,12 @@ func (j *RegoJudge) Eval(input []map[string]interface{}) ([]Result, error) {
 		for _, e := range r.Expressions {
 			for _, i := range e.Value.([]interface{}) {
 				m := i.(map[string]interface{})
+
+				since, err := goversion.NewVersion(m["Since"].(string))
+				if err != nil {
+					return nil, err
+				}
+
 				results = append(results, Result{
 					Name:        m["Name"].(string),
 					Namespace:   m["Namespace"].(string),
@@ -57,7 +64,7 @@ func (j *RegoJudge) Eval(input []map[string]interface{}) ([]Result, error) {
 					ApiVersion:  m["ApiVersion"].(string),
 					ReplaceWith: m["ReplaceWith"].(string),
 					RuleSet:     m["RuleSet"].(string),
-					Since:       m["Since"].(string),
+					Since:       since,
 				})
 			}
 		}

--- a/pkg/printer/filter.go
+++ b/pkg/printer/filter.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"github.com/doitintl/kube-no-trouble/pkg/judge"
+
 	goversion "github.com/hashicorp/go-version"
 )
 

--- a/pkg/printer/filter.go
+++ b/pkg/printer/filter.go
@@ -1,0 +1,22 @@
+package printer
+
+import (
+	"github.com/doitintl/kube-no-trouble/pkg/judge"
+	goversion "github.com/hashicorp/go-version"
+)
+
+func FilterNonRelevantResults(results []judge.Result, tv *goversion.Version) ([]judge.Result, error) {
+	if tv != nil {
+		filtered := []judge.Result{}
+
+		for i := range results {
+			if results[i].Since.LessThanOrEqual(tv) {
+				filtered = append(filtered, results[i])
+			}
+		}
+
+		return filtered, nil
+	}
+
+	return results, nil
+}

--- a/pkg/printer/filter_test.go
+++ b/pkg/printer/filter_test.go
@@ -1,0 +1,74 @@
+package printer
+
+import (
+	"testing"
+
+	"github.com/doitintl/kube-no-trouble/pkg/judge"
+
+	goversion "github.com/hashicorp/go-version"
+)
+
+var testVersion1, _ = goversion.NewVersion("1.1.1")
+var testVersion2, _ = goversion.NewVersion("2.2.2")
+
+var testInput []judge.Result = []judge.Result{
+	{
+		Name:        "testName1",
+		Kind:        "testKind1",
+		Namespace:   "testNamespace1",
+		ApiVersion:  "v1",
+		RuleSet:     "testRuleset1",
+		ReplaceWith: "testReplaceWith1",
+		Since:       testVersion1,
+	},
+	{
+		Name:        "testName2",
+		Kind:        "testKind2",
+		Namespace:   "testNamespace2",
+		ApiVersion:  "v1",
+		RuleSet:     "testRuleset2",
+		ReplaceWith: "testReplaceWith2",
+		Since:       testVersion2,
+	},
+}
+
+func TestFilterNonRelevantResults(t *testing.T) {
+	filterVersion, _ := goversion.NewVersion("2.0.0")
+
+	results, err := FilterNonRelevantResults(testInput, filterVersion)
+	if err != nil {
+		t.Fatalf("failed to filter results: %s", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("expected 1 result after filter, got %d intead", len(results))
+	}
+}
+
+func TestFilterNonRelevantResultsEmpty(t *testing.T) {
+	filterVersion, _ := goversion.NewVersion("2.0.0")
+
+	var input []judge.Result = []judge.Result{}
+
+	results, err := FilterNonRelevantResults(input, filterVersion)
+	if err != nil {
+		t.Fatalf("failed to filter results: %s", err)
+	}
+
+	if len(results) != 0 {
+		t.Errorf("expected 0 results after filter, got %d intead", len(results))
+	}
+}
+
+func TestFilterNonRelevantResultsNilVersion(t *testing.T) {
+	var filterVersion *goversion.Version
+
+	results, err := FilterNonRelevantResults(testInput, filterVersion)
+	if err != nil {
+		t.Fatalf("failed to filter results: %s", err)
+	}
+
+	if len(results) != len(testInput) {
+		t.Errorf("expected same number of results as in input: %d, got %d intead", len(testInput), len(results))
+	}
+}

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -2,38 +2,14 @@ package printer
 
 import (
 	"encoding/json"
-	goversion "github.com/hashicorp/go-version"
 	"testing"
 
 	"github.com/doitintl/kube-no-trouble/pkg/judge"
 )
 
-var testVersion1, _ = goversion.NewVersion("1.2.3")
-
-var findingsJsonTesting []judge.Result = []judge.Result{
-	{
-		Name:        "testName1",
-		Kind:        "testKind1",
-		Namespace:   "testNamespace1",
-		ApiVersion:  "v1",
-		RuleSet:     "testRuleset1",
-		ReplaceWith: "testReplaceWith1",
-		Since:       testVersion1,
-	},
-	{
-		Name:        "testName2",
-		Kind:        "testKind2",
-		Namespace:   "testNamespace2",
-		ApiVersion:  "v1",
-		RuleSet:     "testRuleset2",
-		ReplaceWith: "testReplaceWith2",
-		Since:       testVersion1,
-	},
-}
-
 func TestJsonPopulateOutput(t *testing.T) {
 	printer := &jsonPrinter{}
-	output, err := printer.populateOutput(findingsJsonTesting)
+	output, err := printer.populateOutput(testInput)
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -2,10 +2,13 @@ package printer
 
 import (
 	"encoding/json"
+	goversion "github.com/hashicorp/go-version"
 	"testing"
 
 	"github.com/doitintl/kube-no-trouble/pkg/judge"
 )
+
+var testVersion1, _ = goversion.NewVersion("1.2.3")
 
 var findingsJsonTesting []judge.Result = []judge.Result{
 	{
@@ -15,7 +18,7 @@ var findingsJsonTesting []judge.Result = []judge.Result{
 		ApiVersion:  "v1",
 		RuleSet:     "testRuleset1",
 		ReplaceWith: "testReplaceWith1",
-		Since:       "testSince1",
+		Since:       testVersion1,
 	},
 	{
 		Name:        "testName2",
@@ -24,7 +27,7 @@ var findingsJsonTesting []judge.Result = []judge.Result{
 		ApiVersion:  "v1",
 		RuleSet:     "testRuleset2",
 		ReplaceWith: "testReplaceWith2",
-		Since:       "testSince2",
+		Since:       testVersion1,
 	},
 }
 


### PR DESCRIPTION
This PR implements filtering of non-relevant versions, i.e. versions that the user can't upgrade to as they're not available in the used K8S version.



Closes #130