### PR TITLE
ref: Adjust log level to debug for expected situation when resources are not available

### DIFF
--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -111,7 +111,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		log.Debug().Msgf("Retrieving: %s.%s.%s", g.Resource, g.Version, g.Group)
 		rs, err := ri.List(metav1.ListOptions{})
 		if err != nil {
-			log.Warn().Msgf("Failed to retrieve: %s: %s", g, err)
+			log.Debug().Msgf("Failed to retrieve: %s: %s", g, err)
 			continue
 		}
 


### PR DESCRIPTION
When resources are not available in the cluster, and this is expected to
happen, don't spam users with WARN log messages.

Closes #185