### PR TITLE
fix: Fix nil namespace helm

### DIFF
--- a/pkg/collector/helm.go
+++ b/pkg/collector/helm.go
@@ -33,7 +33,7 @@ func fixNamespace(manifest *map[string]interface{}, defaultNamespace string) {
 	if meta, ok := (*manifest)["metadata"]; ok {
 		switch v := meta.(type) {
 		case map[string]interface{}:
-			if _, ok := v["namespace"]; !ok {
+			if val, ok := v["namespace"]; !ok || val == nil {
 				v["namespace"] = defaultNamespace
 			}
 		}

--- a/pkg/collector/helm.go
+++ b/pkg/collector/helm.go
@@ -1,0 +1,41 @@
+package collector
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"helm.sh/helm/v3/pkg/releaseutil"
+)
+
+func parseManifests(manifest string, defaultNamespace string) ([]map[string]interface{}, error) {
+	var results []map[string]interface{}
+
+	manifests := releaseutil.SplitManifests(manifest)
+	for i, m := range manifests {
+		var manifest map[string]interface{}
+
+		err := yaml.Unmarshal([]byte(m), &manifest)
+		if err != nil {
+			err = fmt.Errorf("failed to parse manifest %s: %v", i, err)
+			return nil, err
+		}
+
+		fixNamespace(&manifest, defaultNamespace)
+
+		results = append(results, manifest)
+	}
+
+	return results, nil
+}
+
+func fixNamespace(manifest *map[string]interface{}, defaultNamespace string) {
+	// Default to the release namespace if the manifest doesn't have the namespace set
+	if meta, ok := (*manifest)["metadata"]; ok {
+		switch v := meta.(type) {
+		case map[string]interface{}:
+			if _, ok := v["namespace"]; !ok {
+				v["namespace"] = defaultNamespace
+			}
+		}
+	}
+}

--- a/pkg/collector/helm3.go
+++ b/pkg/collector/helm3.go
@@ -1,9 +1,7 @@
 package collector
 
 import (
-	"github.com/ghodss/yaml"
 	"github.com/rs/zerolog/log"
-	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/client-go/discovery"
@@ -69,27 +67,10 @@ func (c *HelmV3Collector) Get() ([]map[string]interface{}, error) {
 	var results []map[string]interface{}
 
 	for _, r := range releases {
-		manifests := releaseutil.SplitManifests(r.Manifest)
-		for _, m := range manifests {
-			var manifest map[string]interface{}
-
-			err := yaml.Unmarshal([]byte(m), &manifest)
-			if err != nil {
-				log.Warn().Msgf("failed to parse release %s/%s: %v", r.Namespace, r.Name, err)
-				continue
-			}
-
-			// Default to the release namespace if the manifest doesn't have the namespace set
-			if meta, ok := manifest["metadata"]; ok {
-				switch v := meta.(type) {
-				case map[string]interface{}:
-					if _, ok := v["namespace"]; !ok {
-						v["namespace"] = r.Namespace
-					}
-				}
-			}
-
-			results = append(results, manifest)
+		if manifests, err := parseManifests(r.Manifest, r.Namespace); err != nil {
+			log.Warn().Msgf("failed to parse release %s/%s: %v", r.Namespace, r.Name, err)
+		} else {
+			results = append(results, manifests...)
 		}
 	}
 

--- a/pkg/collector/helm_test.go
+++ b/pkg/collector/helm_test.go
@@ -1,0 +1,87 @@
+package collector
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitManifests(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string // manifest
+		expected int    // kinds of objects
+	}{
+		{"single",
+			"abc: x",
+			1,
+		},
+		{"multiple",
+			"abc: x\n---\ndef: y",
+			2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			manifests, err := parseManifests(tc.input, "default")
+
+			if err != nil {
+				t.Fatalf("Expected to successfully parse manifests: %v", err)
+			}
+
+			if len(manifests) != tc.expected {
+				t.Fatalf("Expected %d manifests, instead got: %d", tc.expected, len(manifests))
+			}
+
+		})
+	}
+}
+
+func TestFixNamespace(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    map[string]interface{} // manifest
+		expected string                 // kinds of objects
+	}{
+		{"present",
+			map[string]interface{}{"metadata": map[string]interface{}{"namespace": "some-namespace"}},
+			"some-namespace",
+		},
+		{"missing",
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			"default-namespace",
+		},
+		{"nil",
+			map[string]interface{}{"metadata": map[string]interface{}{"namespace": nil}},
+			"default-namespace",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			fixNamespace(&tc.input, tc.expected)
+
+			meta, ok := tc.input["metadata"]
+			if !ok {
+				t.Fatalf("Expected fixed manifest to have metadata key")
+			}
+
+			expectedType := "map[string]interface {}"
+			if reflect.TypeOf(meta).String() != expectedType {
+				t.Fatalf("Expected metadata type to be %s, instead got: %T", expectedType, meta)
+			}
+
+			actual, ok := meta.(map[string]interface{})["namespace"]
+			if !ok {
+				t.Fatalf("Expected fixed manifest to have metadata.namespace key")
+			}
+
+			if actual != tc.expected {
+				t.Fatalf("Expected namespace to be: %s, instead got: %s", tc.expected, actual)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This PR should fix #124, after some tests the only way the OPA expressions will return nil namespace is if input has namespace nil / `null` in json. It seems it might be the case with Helm and interface assertions.

Used this opportunity to extract out some dupe code, and cover it with tests.

The `TestFixNamespace/nil` test was first added and failing before the fix.