### PR TITLE
fix: Fix CronJob rego

### DIFF
--- a/pkg/rules/rego/deprecated-1-25.rego
+++ b/pkg/rules/rego/deprecated-1-25.rego
@@ -41,7 +41,7 @@ deprecated_api(kind, api_version) = api {
 			"new": "discovery.k8s.io/v1",
 			"since": "1.21",
 		},
-		"CronJobs": {
+		"CronJob": {
 			"old": ["batch/v1beta1"],
 			"new": "batch/v1",
 			"since": "1.21",


### PR DESCRIPTION
This is a very simple fix that allows deprecated batch/v1beta1 CronJobs to be detected based on last-applied-configuration.
CronJob Kind was incorrectly specified as plural CronJobs.
Resolves #250 