### PR TITLE
Fix tests rules

### DIFF
--- a/fixtures/localsubjectaccessreview-v1beta1.yaml
+++ b/fixtures/localsubjectaccessreview-v1beta1.yaml
@@ -1,5 +1,6 @@
 apiVersion: authorization.k8s.io/v1beta1
 kind: LocalSubjectAccessReview
+metadata:
 spec:
   resourceAttributes:
     group: apps

--- a/fixtures/selfsubjectaccessreview-v1beta1.yaml
+++ b/fixtures/selfsubjectaccessreview-v1beta1.yaml
@@ -1,5 +1,6 @@
 apiVersion: authorization.k8s.io/v1beta1
 kind: SelfSubjectAccessReview
+metadata:
 spec:
   resourceAttributes:
     group: apps

--- a/fixtures/subjectaccessreview-v1beta1.yaml
+++ b/fixtures/subjectaccessreview-v1beta1.yaml
@@ -1,5 +1,6 @@
 apiVersion: authorization.k8s.io/v1beta1
 kind: SubjectAccessReview
+metadata:
 spec:
   resourceAttributes:
     group: apps

--- a/fixtures/tokenreview-v1beta1.yaml
+++ b/fixtures/tokenreview-v1beta1.yaml
@@ -1,5 +1,6 @@
 apiVersion: authentication.k8s.io/v1beta1
 kind: TokenReview
+metadata:
 spec:
   token: "014fbff9a07c..."
   audiences: ["https://myserver.example.com", "https://myserver.internal.example.com"]

--- a/pkg/rules/rego/deprecated-1-16.rego
+++ b/pkg/rules/rego/deprecated-1-16.rego
@@ -4,7 +4,7 @@ main[return] {
 	resource := input[_]
 	api := deprecated_resource(resource)
 	return := {
-		"Name": resource.metadata.name,
+		"Name": get_default(resource.metadata, "name", "<undefined>"),
 		# Namespace does not have to be defined in case of local manifests
 		"Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
 		"Kind": resource.kind,

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -4,7 +4,7 @@ main[return] {
 	resource := input[_]
 	api := deprecated_resource(resource)
 	return := {
-		"Name": resource.metadata.name,
+		"Name": get_default(resource.metadata, "name", "<undefined>"),
 		# Namespace does not have to be defined in case of local manifests
 		"Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
 		"Kind": resource.kind,

--- a/pkg/rules/rego/deprecated-1-25.rego
+++ b/pkg/rules/rego/deprecated-1-25.rego
@@ -4,7 +4,7 @@ main[return] {
 	resource := input[_]
 	api := deprecated_resource(resource)
 	return := {
-		"Name": resource.metadata.name,
+		"Name": get_default(resource.metadata, "name", "<undefined>"),
 		# Namespace does not have to be defined in case of local manifests
 		"Namespace": get_default(resource.metadata, "namespace", "<undefined>"),
 		"Kind": resource.kind,


### PR DESCRIPTION
This PR fixes non-working rules tests #252 and 2 other minor issues discovered once the tests started to work as expected:
- test: Fix review* fixture manifests to contain metadata
- fix: Resource name can be undefined in some cases