### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ fi
 You can also use `--exit-error` (`-e`) flag, which will make kubent to exit
 with non-zero return code (`200`) in case any issues are found.
 
-Alternatively, use the json output and smth. like `jq` to check if the result is
+Alternatively, use the json output and something. like `jq` to check if the result is
 empty:
 
 ```

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Where type is one of:
 - **docs** - Documentation only change
 - **feat** - A new feature
 - **fix** - A bug fix
-- **ref** - Code refactoring without functinality change
+- **ref** - Code refactoring without functionality change
 - **style** - Formatting changes
 - **test** - Adding/changing tests
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Configure Kubectl's current context to point to your cluster, `kubent` will
 look for the kube `.config` file in standard locations (you can point it to custom
 location using the `-k` switch).
 
-**`kubent`** will collect resources from your cluster and report on found issuses.
+**`kubent`** will collect resources from your cluster and report on found issues.
 
 *Please note that you need to have sufficient permissions to read Secrets in the
 cluster in order to use `Helm*` collectors.*
@@ -115,7 +115,7 @@ during runtime. Because all info output goes to stderr, it's easy to check in
 shell if any issues were found:
 
 ```shell
-test -z "$(kubent)"                 # if stdout output is empty, means no issuse were found
+test -z "$(kubent)"                 # if stdout output is empty, means no issues were found
                                     # equivalent to [ -z "$(kubent)" ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Usage of ./kubent:
   Select context from kubeconfig file (`current-context` from the file is used by default).
 
 - *`k, --kubeconfig`*
-  Path to kubeconfig file to use. This takes precedence over `KUBECONFIG` environemnt variable, which is also supported
+  Path to kubeconfig file to use. This takes precedence over `KUBECONFIG` environment variable, which is also supported
   and can contain multiple paths, and default `~.kube/config`.
 
 - *`-t, --target-version`*

--- a/cmd/kubent/main_test.go
+++ b/cmd/kubent/main_test.go
@@ -116,7 +116,7 @@ func TestMainExitCodes(t *testing.T) {
 	if os.Getenv("TEST_EXIT_CODE") == "1" {
 		tc, err := strconv.Atoi(os.Getenv("TEST_CASE"))
 		if err != nil {
-			t.Errorf("failed to determin the test case num (TEST_CASE env var): %v", err)
+			t.Errorf("failed to determine the test case num (TEST_CASE env var): %v", err)
 		}
 
 		os.Args = []string{os.Args[0]}

--- a/pkg/collector/file_test.go
+++ b/pkg/collector/file_test.go
@@ -94,7 +94,7 @@ func TestFileCollectorGetNonExistent(t *testing.T) {
 	_, err = c.Get()
 
 	if err == nil {
-		t.Errorf("Expected error with non-existent file type")
+		t.Errorf("Expected error with nonexistent file type")
 	} else if !strings.Contains(err.Error(), expected) {
 		t.Errorf("Expected error message with %s, got %s", expected, err.Error())
 	}

--- a/pkg/collector/kube_test.go
+++ b/pkg/collector/kube_test.go
@@ -95,7 +95,7 @@ func TestContextMissing(t *testing.T) {
 
 	_, err := newKubeCollector(filepath.Join(FIXTURES_DIR, "kube.config.context"), expectedContext, nil)
 	if err == nil {
-		t.Fatalf("Expected to fail when uisng nonexistent context: %s", expectedContext)
+		t.Fatalf("Expected to fail when using nonexistent context: %s", expectedContext)
 	}
 }
 
@@ -144,7 +144,7 @@ func TestNewClientRestConfigContextMissing(t *testing.T) {
 
 	_, err := newClientRestConfig(filepath.Join(FIXTURES_DIR, "kube.config.context"), expectedContext, rest.InClusterConfig)
 	if err == nil {
-		t.Fatalf("Expected to fail when uisng nonexistent context: %s", expectedContext)
+		t.Fatalf("Expected to fail when using nonexistent context: %s", expectedContext)
 	}
 }
 

--- a/pkg/collector/kube_test.go
+++ b/pkg/collector/kube_test.go
@@ -47,7 +47,7 @@ func TestNewKubeCollectorError(t *testing.T) {
 	_, err := newKubeCollector("does-not-exist", "", nil)
 
 	if err == nil {
-		t.Errorf("Expected to fail with non-existent kubeconfig")
+		t.Errorf("Expected to fail with nonexistent kubeconfig")
 	}
 }
 
@@ -91,11 +91,11 @@ func TestContext(t *testing.T) {
 }
 
 func TestContextMissing(t *testing.T) {
-	expectedContext := "non-existent"
+	expectedContext := "nonexistent"
 
 	_, err := newKubeCollector(filepath.Join(FIXTURES_DIR, "kube.config.context"), expectedContext, nil)
 	if err == nil {
-		t.Fatalf("Expected to fail when uisng non-existent context: %s", expectedContext)
+		t.Fatalf("Expected to fail when uisng nonexistent context: %s", expectedContext)
 	}
 }
 
@@ -103,7 +103,7 @@ func TestNewClientRestConfigError(t *testing.T) {
 	_, err := newClientRestConfig("does-not-exist", "", rest.InClusterConfig)
 
 	if err == nil {
-		t.Errorf("Expected to fail with non-existent kubeconfig")
+		t.Errorf("Expected to fail with nonexistent kubeconfig")
 	}
 }
 
@@ -140,11 +140,11 @@ func TestNewClientRestConfigWithContext(t *testing.T) {
 }
 
 func TestNewClientRestConfigContextMissing(t *testing.T) {
-	expectedContext := "non-existent"
+	expectedContext := "nonexistent"
 
 	_, err := newClientRestConfig(filepath.Join(FIXTURES_DIR, "kube.config.context"), expectedContext, rest.InClusterConfig)
 	if err == nil {
-		t.Fatalf("Expected to fail when uisng non-existent context: %s", expectedContext)
+		t.Fatalf("Expected to fail when uisng nonexistent context: %s", expectedContext)
 	}
 }
 

--- a/pkg/printer/filter_test.go
+++ b/pkg/printer/filter_test.go
@@ -48,7 +48,7 @@ func TestFilterNonRelevantResults(t *testing.T) {
 	}
 
 	if len(results) != 1 {
-		t.Errorf("expected 1 result after filter, got %d intead", len(results))
+		t.Errorf("expected 1 result after filter, got %d instead", len(results))
 	}
 }
 
@@ -63,7 +63,7 @@ func TestFilterNonRelevantResultsEmpty(t *testing.T) {
 	}
 
 	if len(results) != 0 {
-		t.Errorf("expected 0 results after filter, got %d intead", len(results))
+		t.Errorf("expected 0 results after filter, got %d instead", len(results))
 	}
 }
 
@@ -76,7 +76,7 @@ func TestFilterNonRelevantResultsWithNilVersion(t *testing.T) {
 	}
 
 	if len(results) != 1 {
-		t.Errorf("expected 1 results after filter, got %d intead", len(results))
+		t.Errorf("expected 1 results after filter, got %d instead", len(results))
 	}
 }
 
@@ -89,6 +89,6 @@ func TestFilterNonRelevantResultsNilTargetVersion(t *testing.T) {
 	}
 
 	if len(results) != len(testInput) {
-		t.Errorf("expected same number of results as in input: %d, got %d intead", len(testInput), len(results))
+		t.Errorf("expected same number of results as in input: %d, got %d instead", len(testInput), len(results))
 	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,11 +71,11 @@ sudo=""
 
 if [ ! -w "${TARGET_DIR}" ]; then
   if [ -x "$(command -v 'sudo')" ]; then
-    echo "Target diectory (${TARGET_DIR}) is not writable, trying to use sudo"
+    echo "Target directory (${TARGET_DIR}) is not writable, trying to use sudo"
     sudo="sudo"
   fi
   ${sudo} [ -w "${TARGET_DIR}" ] \
-    || fail "Target diectory (${TARGET_DIR}) is not writable (destination can be changed using \$TARGET_DIR variable)"
+    || fail "Target directory (${TARGET_DIR}) is not writable (destination can be changed using \$TARGET_DIR variable)"
 fi
 
 curl -L -o- "https://github.com/${GITHUB_REPO}/releases/download/${version}/${APP_NAME}-${version}-${TARGET_OS}-${TARGET_ARCH}.tar.gz" \

--- a/test/helper.go
+++ b/test/helper.go
@@ -16,7 +16,7 @@ type resourceFixtureTestCase struct {
 	expectedKinds []string
 }
 
-func testReourcesUsingFixtures(t *testing.T, testCases []resourceFixtureTestCase) {
+func testResourcesUsingFixtures(t *testing.T, testCases []resourceFixtureTestCase) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := collector.NewFileCollector(

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -29,5 +29,5 @@ func TestRego122(t *testing.T) {
 		{"ValidatingWebhookConfiguration", []string{"../fixtures/validatingwebhookconfiguration-v1beta1.yaml"}, []string{"ValidatingWebhookConfiguration"}},
 	}
 
-	testReourcesUsingFixtures(t, testCases)
+	testResourcesUsingFixtures(t, testCases)
 }

--- a/test/rules_125_test.go
+++ b/test/rules_125_test.go
@@ -13,5 +13,5 @@ func TestRego125(t *testing.T) {
 		{"CronJob", []string{"../fixtures/cronjob-v1beta1.yaml"}, []string{"CronJob"}},
 	}
 
-	testReourcesUsingFixtures(t, testCases)
+	testResourcesUsingFixtures(t, testCases)
 }


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/kube-no-trouble/commit/cc2ec75b393971a8a6d764307a6106c35c09fa7e#commitcomment-77235244

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/kube-no-trouble/commit/812c67155c209c7c4242f1779487a264cbf1f444

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

I understand that there's a linter that objects to my commit messages. I'm happy to squash the commits into a single PR once the general set of changes are reviewed and I've dropped any that may be objectionable.