### PR TITLE
feat: Support for checking additional annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,19 +76,24 @@ You can list all the configuration options available using `--help` switch:
 ```sh
 $./kubent -h
 Usage of ./kubent:
-  -a, --additional-kind strings   additional kinds of resources to report in Kind.version.group.com format
-  -c, --cluster                   enable Cluster collector (default true)
-  -x, --context string            kubeconfig context
-  -e, --exit-error                exit with non-zero code when issues are found
-  -f, --filename strings          manifests to check, use - for stdin
-      --helm2                     enable Helm v2 collector (default true)
-      --helm3                     enable Helm v3 collector (default true)
-  -k, --kubeconfig string         path to the kubeconfig file
-  -l, --log-level string          set log level (trace, debug, info, warn, error, fatal, panic, disabled) (default "info")
-  -o, --output string             output format - [text|json] (default "text")
-  -t, --target-version string     target K8s version in SemVer format (autodetected by default)
-  -v, --version                   prints the version of kubent and exits
+  -A, --additional-annotation strings   additional annotations that should be checked to determine the last applied config
+  -a, --additional-kind strings         additional kinds of resources to report in Kind.version.group.com format
+  -c, --cluster                         enable Cluster collector (default true)
+  -x, --context string                  kubeconfig context
+  -e, --exit-error                      exit with non-zero code when issues are found
+  -f, --filename strings                manifests to check, use - for stdin
+      --helm2                           enable Helm v2 collector (default true)
+      --helm3                           enable Helm v3 collector (default true)
+  -k, --kubeconfig string               path to the kubeconfig file
+  -l, --log-level string                set log level (trace, debug, info, warn, error, fatal, panic, disabled) (default "info")
+  -o, --output string                   output format - [text|json] (default "text")
+  -t, --target-version string           target K8s version in SemVer format (autodetected by default)
+  -v, --version                         prints the version of kubent and exits
+
 ```
+- *`--additional-annotation`*
+  Check additional annotations for the last applied configuration. This can be useful if a resource was applied
+  with a tool other than kubectl. The flag can be used multiple times.
 
 - *`-a, --additional-kind`*
   Tells `kubent` to flag additional custom resources when found in the specified version. The flag can be used multiple

--- a/cmd/kubent/main.go
+++ b/cmd/kubent/main.go
@@ -59,7 +59,8 @@ func storeCollector(collector collector.Collector, err error, collectors []colle
 func initCollectors(config *config.Config) []collector.Collector {
 	collectors := []collector.Collector{}
 	if config.Cluster {
-		collector, err := collector.NewClusterCollector(&collector.ClusterOpts{Kubeconfig: config.Kubeconfig, KubeContext: config.Context}, config.AdditionalKinds, generateUserAgent())
+		collector, err := collector.NewClusterCollector(&collector.ClusterOpts{Kubeconfig: config.Kubeconfig, KubeContext: config.Context},
+			config.AdditionalKinds, config.AdditionalAnnotations, generateUserAgent())
 		collectors = storeCollector(collector, err, collectors)
 	}
 

--- a/fixtures/fake-deployment-v1beta1-with-kapp-annotation.yaml
+++ b/fixtures/fake-deployment-v1beta1-with-kapp-annotation.yaml
@@ -1,0 +1,71 @@
+# fake client resource are a bit special
+# apiVersion need to match versions we're collection, i.e. apps/v1
+# true version is taken from kubectl.kubernetes.io/last-applied-configuration
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    kapp.k14s.io/original: |
+      {"apiVersion":"apps/v1beta1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"nginx"},"name":"nginx-deployment-old","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"nginx"}},"template":{"metadata":{"labels":{"app":"nginx"}},"spec":{"containers":[{"image":"nginx:1.14.2","name":"nginx","ports":[{"containerPort":80}]}]}}}}
+  creationTimestamp: "2020-09-04T19:51:38Z"
+  generation: 1
+  labels:
+    app: nginx
+  name: nginx-deployment-old
+  namespace: default
+  resourceVersion: "647052"
+  selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/nginx-deployment-old
+  uid: 93674123-01f1-4a10-a829-ff0751cf13da
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx:1.14.2
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 3
+  conditions:
+  - lastTransitionTime: "2020-09-04T19:51:48Z"
+    lastUpdateTime: "2020-09-04T19:51:48Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2020-09-04T19:51:38Z"
+    lastUpdateTime: "2020-09-04T19:51:48Z"
+    message: ReplicaSet "nginx-deployment-old-7fd6966748" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  observedGeneration: 1
+  readyReplicas: 3
+  replicas: 3
+  updatedReplicas: 3

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,18 +13,19 @@ import (
 )
 
 type Config struct {
-	AdditionalKinds []string
-	Cluster         bool
-	Context         string
-	ExitError       bool
-	Filenames       []string
-	Helm2           bool
-	Helm3           bool
-	Kubeconfig      string
-	LogLevel        ZeroLogLevel
-	Output          string
-	TargetVersion   *judge.Version
-	KubentVersion   bool
+	AdditionalKinds       []string
+	AdditionalAnnotations []string
+	Cluster               bool
+	Context               string
+	ExitError             bool
+	Filenames             []string
+	Helm2                 bool
+	Helm3                 bool
+	Kubeconfig            string
+	LogLevel              ZeroLogLevel
+	Output                string
+	TargetVersion         *judge.Version
+	KubentVersion         bool
 }
 
 func NewFromFlags() (*Config, error) {
@@ -34,6 +35,7 @@ func NewFromFlags() (*Config, error) {
 	}
 
 	flag.StringSliceVarP(&config.AdditionalKinds, "additional-kind", "a", []string{}, "additional kinds of resources to report in Kind.version.group.com format")
+	flag.StringSliceVarP(&config.AdditionalAnnotations, "additional-annotation", "A", []string{}, "additional annotations that should be checked to determine the last applied config")
 	flag.BoolVarP(&config.Cluster, "cluster", "c", true, "enable Cluster collector")
 	flag.StringVarP(&config.Context, "context", "x", "", "kubeconfig context")
 	flag.BoolVarP(&config.ExitError, "exit-error", "e", false, "exit with non-zero code when issues are found")


### PR DESCRIPTION
Currently, kubent only checks the `kubectl.kubernetes.io/last-applied-configuration` annotation for deprecated APIs, which is set by kubectl. If a different tool like [kapp](https://github.com/vmware-tanzu/carvel-kapp) is used, which might set other annotations, kubent won't detect those.

This PR adds support for checking additional annotations. It can be activated via the `--additional-annotations` flag.

**Example:**
```shell
kubent -t v1.22 --additional-annotations kapp.k14s.io/original
```

The change is backward compatible, as the `kubectl.kubernetes.io/last-applied-configuration` annotation will always be checked first. Only if that annotation is not set the additional annotations are tried.