### PR TITLE
feat: Cover deprecated autoscaling/v2beta1 API group - HPA

### DIFF
--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -98,7 +98,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"},
 		schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"},
 		schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"},
-		schema.GroupVersionResource{Group: "autoscaling", Version: "v2beta1", Resource: "horizontalpodautoscalers"},
+		schema.GroupVersionResource{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -98,6 +98,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"},
 		schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"},
 		schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"},
+		schema.GroupVersionResource{Group: "autoscaling", Version: "v2beta1", Resource: "horizontalpodautoscalers"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,7 +33,7 @@ func NewFromFlags() (*Config, error) {
 		TargetVersion: &judge.Version{},
 	}
 
-	flag.StringSliceVarP(&config.AdditionalKinds, "additional-kind", "a", []string{}, "additional kinds of resources to report in Kind.version.group.com format")
+	flag.StringSliceVarP(&config.AdditionalKinds, "additional-kind", "a", []string{}, "additional kinds of resources to report in Kind.version.group format")
 	flag.BoolVarP(&config.Cluster, "cluster", "c", true, "enable Cluster collector")
 	flag.StringVarP(&config.Context, "context", "x", "", "kubeconfig context")
 	flag.BoolVarP(&config.ExitError, "exit-error", "e", false, "exit with non-zero code when issues are found")
@@ -67,12 +67,12 @@ func NewFromFlags() (*Config, error) {
 }
 
 // validateAdditionalResources check that all resources are provided in full form
-// resource.version.group.com. E.g. managedcertificate.v1beta1.networking.gke.io
+// resource.version.group. E.g. managedcertificate.v1beta1.networking.gke.io
 func validateAdditionalResources(resources []string) error {
 	for _, r := range resources {
 		parts := strings.Split(r, ".")
-		if len(parts) < 4 {
-			return fmt.Errorf("failed to parse additional Kind, full form Kind.version.group.com is expected, instead got: %s", r)
+		if len(parts) < 3 {
+			return fmt.Errorf("failed to parse additional Kind, full form Kind.version.group is expected, instead got: %s", r)
 		}
 
 		if !unicode.IsUpper(rune(parts[0][0])) {

--- a/pkg/rules/rego/deprecated-1-25.rego
+++ b/pkg/rules/rego/deprecated-1-25.rego
@@ -46,6 +46,11 @@ deprecated_api(kind, api_version) = api {
 			"new": "batch/v1",
 			"since": "1.21",
 		},
+		"HorizontalPodAutoscaler": {
+			"old": ["autoscaling/v2beta1"],
+			"new": "autoscaling/v2",
+			"since": "1.23",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version


### PR DESCRIPTION
Adding a scan for the HorizontalPodAutoscaler. API version autoscaling/v2beta1 was removed in 1.25 as well as the others here.