### PR TITLE
feat: Cover deprecated autoscaling/v2beta1 API group - HPA

### DIFF
--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -98,6 +98,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"},
 		schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"},
 		schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"},
+		schema.GroupVersionResource{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-25.rego
+++ b/pkg/rules/rego/deprecated-1-25.rego
@@ -46,6 +46,11 @@ deprecated_api(kind, api_version) = api {
 			"new": "batch/v1",
 			"since": "1.21",
 		},
+		"HorizontalPodAutoscaler": {
+			"old": ["autoscaling/v2beta1"],
+			"new": "autoscaling/v2",
+			"since": "1.23",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version


### PR DESCRIPTION
feat: Cover deprecated autoscaling/v2beta1 API group - HorizontalPodAutoscaler

    As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/
    add autoscaling/v2beta1 - HorizontalPodAutoscaler resource.