### PR TITLE
feat: Add handling simple resource groups

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,7 +33,7 @@ func NewFromFlags() (*Config, error) {
 		TargetVersion: &judge.Version{},
 	}
 
-	flag.StringSliceVarP(&config.AdditionalKinds, "additional-kind", "a", []string{}, "additional kinds of resources to report in Kind.version.group.com format")
+	flag.StringSliceVarP(&config.AdditionalKinds, "additional-kind", "a", []string{}, "additional kinds of resources to report in Kind.version.group format")
 	flag.BoolVarP(&config.Cluster, "cluster", "c", true, "enable Cluster collector")
 	flag.StringVarP(&config.Context, "context", "x", "", "kubeconfig context")
 	flag.BoolVarP(&config.ExitError, "exit-error", "e", false, "exit with non-zero code when issues are found")
@@ -67,12 +67,12 @@ func NewFromFlags() (*Config, error) {
 }
 
 // validateAdditionalResources check that all resources are provided in full form
-// resource.version.group.com. E.g. managedcertificate.v1beta1.networking.gke.io
+// resource.version.group. E.g. managedcertificate.v1beta1.networking.gke.io
 func validateAdditionalResources(resources []string) error {
 	for _, r := range resources {
 		parts := strings.Split(r, ".")
-		if len(parts) < 4 {
-			return fmt.Errorf("failed to parse additional Kind, full form Kind.version.group.com is expected, instead got: %s", r)
+		if len(parts) < 3 {
+			return fmt.Errorf("failed to parse additional Kind, full form Kind.version.group is expected, instead got: %s", r)
 		}
 
 		if !unicode.IsUpper(rune(parts[0][0])) {


### PR DESCRIPTION
 feat: Add handling simple resource groups when adding additional kinds to scan

   If the API version is not included in the code for resources in groups apps, batch,
   autoscaling, etc, add the ability to scan for those resources using the -a option.