### PR TITLE
chore: Fixing spelling and add pre-commit for it

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -130,7 +130,7 @@ jobs:
           draft: ${{ startsWith(steps.get_tag.outputs.git_tag, 'nightly') != true }}
           prerelease: ${{ startsWith(steps.get_tag.outputs.git_tag, 'nightly') }}
   release-artifacts:
-    name: Relase Artifacts
+    name: Release Artifacts
     needs:
       [create-release]
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,7 @@ repos:
     rev: v2.2.0
     hooks:
       - id: pretty-format-golang
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.1
+    hooks:
+      - id: codespell

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Configure Kubectl's current context to point to your cluster, `kubent` will
 look for the kube `.config` file in standard locations (you can point it to custom
 location using the `-k` switch).
 
-**`kubent`** will collect resources from your cluster and report on found issuses.
+**`kubent`** will collect resources from your cluster and report on found issues.
 
 *Please note that you need to have sufficient permissions to read Secrets in the
 cluster in order to use `Helm*` collectors.*
@@ -98,7 +98,7 @@ Usage of ./kubent:
   Select context from kubeconfig file (`current-context` from the file is used by default).
 
 - *`k, --kubeconfig`*
-  Path to kubeconfig file to use. This takes precedence over `KUBECONFIG` environemnt variable, which is also supported
+  Path to kubeconfig file to use. This takes precedence over `KUBECONFIG` environment variable, which is also supported
   and can contain multiple paths, and default `~.kube/config`.
 
 - *`-t, --target-version`*
@@ -117,7 +117,7 @@ during runtime. Because all info output goes to stderr, it's easy to check in
 shell if any issues were found:
 
 ```shell
-test -z "$(kubent)"                 # if stdout output is empty, means no issuse were found
+test -z "$(kubent)"                 # if stdout output is empty, means no issues were found
                                     # equivalent to [ -z "$(kubent)" ]
 ```
 
@@ -195,7 +195,7 @@ Where type is one of:
 - **docs** - Documentation only change
 - **feat** - A new feature
 - **fix** - A bug fix
-- **ref** - Code refactoring without functinality change
+- **ref** - Code refactoring without functionality change
 - **style** - Formatting changes
 - **test** - Adding/changing tests
 

--- a/cmd/kubent/main_test.go
+++ b/cmd/kubent/main_test.go
@@ -123,7 +123,7 @@ func TestMainExitCodes(t *testing.T) {
 	if os.Getenv("TEST_EXIT_CODE") == "1" {
 		tc, err := strconv.Atoi(os.Getenv("TEST_CASE"))
 		if err != nil {
-			t.Errorf("failed to determin the test case num (TEST_CASE env var): %v", err)
+			t.Errorf("failed to determine the test case num (TEST_CASE env var): %v", err)
 		}
 
 		os.Args = []string{os.Args[0]}

--- a/pkg/collector/file_test.go
+++ b/pkg/collector/file_test.go
@@ -94,7 +94,7 @@ func TestFileCollectorGetNonExistent(t *testing.T) {
 	_, err = c.Get()
 
 	if err == nil {
-		t.Errorf("Expected error with non-existent file type")
+		t.Errorf("Expected error with nonexistent file type")
 	} else if !strings.Contains(err.Error(), expected) {
 		t.Errorf("Expected error message with %s, got %s", expected, err.Error())
 	}

--- a/pkg/collector/kube_test.go
+++ b/pkg/collector/kube_test.go
@@ -51,7 +51,7 @@ func TestNewKubeCollectorError(t *testing.T) {
 	_, err := newKubeCollector("does-not-exist", "", nil, USER_AGENT)
 
 	if err == nil {
-		t.Errorf("Expected to fail with non-existent kubeconfig")
+		t.Errorf("Expected to fail with nonexistent kubeconfig")
 	}
 }
 
@@ -95,11 +95,11 @@ func TestContext(t *testing.T) {
 }
 
 func TestContextMissing(t *testing.T) {
-	expectedContext := "non-existent"
+	expectedContext := "nonexistent"
 
 	_, err := newKubeCollector(filepath.Join(FIXTURES_DIR, CONTEXT), expectedContext, nil, USER_AGENT)
 	if err == nil {
-		t.Fatalf("Expected to fail when uisng non-existent context: %s", expectedContext)
+		t.Fatalf("Expected to fail when uisng nonexistent context: %s", expectedContext)
 	}
 }
 
@@ -107,7 +107,7 @@ func TestNewClientRestConfigError(t *testing.T) {
 	_, err := newClientRestConfig("does-not-exist", "", rest.InClusterConfig, USER_AGENT)
 
 	if err == nil {
-		t.Errorf("Expected to fail with non-existent kubeconfig")
+		t.Errorf("Expected to fail with nonexistent kubeconfig")
 	}
 }
 
@@ -144,11 +144,11 @@ func TestNewClientRestConfigWithContext(t *testing.T) {
 }
 
 func TestNewClientRestConfigContextMissing(t *testing.T) {
-	expectedContext := "non-existent"
+	expectedContext := "nonexistent"
 
 	_, err := newClientRestConfig(filepath.Join(FIXTURES_DIR, CONTEXT), expectedContext, rest.InClusterConfig, USER_AGENT)
 	if err == nil {
-		t.Fatalf("Expected to fail when uisng non-existent context: %s", expectedContext)
+		t.Fatalf("Expected to fail when uisng nonexistent context: %s", expectedContext)
 	}
 }
 

--- a/pkg/collector/kube_test.go
+++ b/pkg/collector/kube_test.go
@@ -99,7 +99,7 @@ func TestContextMissing(t *testing.T) {
 
 	_, err := newKubeCollector(filepath.Join(FIXTURES_DIR, CONTEXT), expectedContext, nil, USER_AGENT)
 	if err == nil {
-		t.Fatalf("Expected to fail when uisng nonexistent context: %s", expectedContext)
+		t.Fatalf("Expected to fail when using nonexistent context: %s", expectedContext)
 	}
 }
 
@@ -148,7 +148,7 @@ func TestNewClientRestConfigContextMissing(t *testing.T) {
 
 	_, err := newClientRestConfig(filepath.Join(FIXTURES_DIR, CONTEXT), expectedContext, rest.InClusterConfig, USER_AGENT)
 	if err == nil {
-		t.Fatalf("Expected to fail when uisng nonexistent context: %s", expectedContext)
+		t.Fatalf("Expected to fail when using nonexistent context: %s", expectedContext)
 	}
 }
 

--- a/pkg/printer/filter_test.go
+++ b/pkg/printer/filter_test.go
@@ -48,7 +48,7 @@ func TestFilterNonRelevantResults(t *testing.T) {
 	}
 
 	if len(results) != 1 {
-		t.Errorf("expected 1 result after filter, got %d intead", len(results))
+		t.Errorf("expected 1 result after filter, got %d instead", len(results))
 	}
 }
 
@@ -63,7 +63,7 @@ func TestFilterNonRelevantResultsEmpty(t *testing.T) {
 	}
 
 	if len(results) != 0 {
-		t.Errorf("expected 0 results after filter, got %d intead", len(results))
+		t.Errorf("expected 0 results after filter, got %d instead", len(results))
 	}
 }
 
@@ -76,7 +76,7 @@ func TestFilterNonRelevantResultsWithNilVersion(t *testing.T) {
 	}
 
 	if len(results) != 1 {
-		t.Errorf("expected 1 results after filter, got %d intead", len(results))
+		t.Errorf("expected 1 results after filter, got %d instead", len(results))
 	}
 }
 
@@ -89,6 +89,6 @@ func TestFilterNonRelevantResultsNilTargetVersion(t *testing.T) {
 	}
 
 	if len(results) != len(testInput) {
-		t.Errorf("expected same number of results as in input: %d, got %d intead", len(testInput), len(results))
+		t.Errorf("expected same number of results as in input: %d, got %d instead", len(testInput), len(results))
 	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,11 +80,11 @@ download_version() {
 
   if [ ! -w "${TARGET_DIR}" ]; then
     if [ -x "$(command -v 'sudo')" ]; then
-      echo "Target diectory (${TARGET_DIR}) is not writable, trying to use sudo"
+      echo "Target directory (${TARGET_DIR}) is not writable, trying to use sudo"
       sudo="sudo"
     fi
     ${sudo} [ -w "${TARGET_DIR}" ] \
-      || fail "Target diectory (${TARGET_DIR}) is not writable (destination can be changed using \$TARGET_DIR variable)"
+      || fail "Target directory (${TARGET_DIR}) is not writable (destination can be changed using \$TARGET_DIR variable)"
   fi
 
   curl -L -o- "https://github.com/${GITHUB_REPO}/releases/download/${version}/${APP_NAME}-${version}-${TARGET_OS}-${TARGET_ARCH}.tar.gz" \

--- a/test/helper_test.go
+++ b/test/helper_test.go
@@ -20,7 +20,7 @@ func init() {
 	Setup()
 }
 
-func testReourcesUsingFixtures(t *testing.T, testCases []resourceFixtureTestCase) {
+func testResourcesUsingFixtures(t *testing.T, testCases []resourceFixtureTestCase) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := collector.NewFileCollector(

--- a/test/rules_122_test.go
+++ b/test/rules_122_test.go
@@ -29,5 +29,5 @@ func TestRego122(t *testing.T) {
 		{"ValidatingWebhookConfiguration", []string{"../fixtures/validatingwebhookconfiguration-v1beta1.yaml"}, []string{"ValidatingWebhookConfiguration"}},
 	}
 
-	testReourcesUsingFixtures(t, testCases)
+	testResourcesUsingFixtures(t, testCases)
 }

--- a/test/rules_125_test.go
+++ b/test/rules_125_test.go
@@ -13,5 +13,5 @@ func TestRego125(t *testing.T) {
 		{"CronJob", []string{"../fixtures/cronjob-v1beta1.yaml"}, []string{"CronJob"}},
 	}
 
-	testReourcesUsingFixtures(t, testCases)
+	testResourcesUsingFixtures(t, testCases)
 }

--- a/test/rules_future_test.go
+++ b/test/rules_future_test.go
@@ -11,5 +11,5 @@ func TestRegoFuture(t *testing.T) {
 		{"VolumeSnapshotContent", []string{"../fixtures/volumesnapshotcontent-v1beta1.yaml"}, []string{"VolumeSnapshotContent"}},
 	}
 
-	testReourcesUsingFixtures(t, testCases)
+	testResourcesUsingFixtures(t, testCases)
 }


### PR DESCRIPTION
This should fix spelling mistakes and future spelling mistakes. I have chosen to go with a pre-commit so it can be run locally ensuring that users can check for spelling mistakes on their own.