### PR TITLE
Add support for configuring output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Usage of ./kubent:
   -k, --kubeconfig string               path to the kubeconfig file
   -l, --log-level string                set log level (trace, debug, info, warn, error, fatal, panic, disabled) (default "info")
   -o, --output string                   output format - [text|json] (default "text")
+  -O, --output-file string        output file, use - for stdout (default "-")
   -t, --target-version string           target K8s version in SemVer format (autodetected by default)
   -v, --version                         prints the version of kubent and exits
-
 ```
 - *`--additional-annotation`*
   Check additional annotations for the last applied configuration. This can be useful if a resource was applied

--- a/cmd/kubent/main.go
+++ b/cmd/kubent/main.go
@@ -155,14 +155,9 @@ func main() {
 		log.Fatal().Err(err).Str("name", "Rego").Msg("Failed to filter results")
 	}
 
-	printer, err := printer.NewPrinter(config.Output)
+	err = outputResults(results, config.Output, config.OutputFile)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to create printer")
-	}
-
-	err = printer.Print(results)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to print results")
+		log.Fatal().Err(err).Msgf("Failed to output results")
 	}
 
 	if config.ExitError && len(results) > 0 {
@@ -171,4 +166,19 @@ func main() {
 		exitCode = EXIT_CODE_SUCCESS
 	}
 	os.Exit(exitCode)
+}
+
+func outputResults(results []judge.Result, outputType string, outputFile string) error {
+	printer, err := printer.NewPrinter(outputType, outputFile)
+	if err != nil {
+		return fmt.Errorf("failed to create printer: %v", err)
+	}
+	defer printer.Close()
+
+	err = printer.Print(results)
+	if err != nil {
+		return fmt.Errorf("failed to print results: %v", err)
+	}
+
+	return nil
 }

--- a/cmd/kubent/main_test.go
+++ b/cmd/kubent/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -102,25 +103,36 @@ func TestStoreCollectorError(t *testing.T) {
 }
 
 func TestMainExitCodes(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "kubent-tests-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	expectedJsonOutput, _ := os.ReadFile(filepath.Join(FIXTURES_DIR, "expected-json-output.json"))
 	helm2FlagDisabled := "--helm2=false"
 	helm3FlagDisabled := "--helm3=false"
 	clusterFlagDisabled := "--cluster=false"
 	testCases := []struct {
-		name     string
-		args     []string // file list
-		expected int      // number of manifests
-		stdout   string   // stdout
+		name        string
+		args        []string // file list
+		expected    int      // expected exit code
+		stdout      string   // expected stdout
+		outFileName string
 	}{
-		{"success", []string{clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled}, 0, ""},
-		{"errorBadFlag", []string{"-c=not-boolean"}, 2, ""},
-		{"successFound", []string{"-o=json", clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled, "-f=" + filepath.Join(FIXTURES_DIR, "deployment-v1beta1.yaml")}, 0, string(expectedJsonOutput)},
-		{"exitErrorFlagNone", []string{clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled, "-e"}, 0, ""},
-		{"exitErrorFlagFound", []string{clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled, "-e", "-f=" + filepath.Join(FIXTURES_DIR, "deployment-v1beta1.yaml")}, 200, ""},
-		{"version short flag set", []string{"-v"}, 0, ""},
-		{"version long flag set", []string{"--version"}, 0, ""},
-		{"empty text output", []string{}, 0, ""},
-		{"empty json output", []string{"-o=json"}, 0, "[]\n"},
+		{"success", []string{clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled}, 0, "", ""},
+		{"errorBadFlag", []string{"-c=not-boolean"}, 2, "", ""},
+		{"successFound", []string{"-o=json", clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled, "-f=" + filepath.Join(FIXTURES_DIR, "deployment-v1beta1.yaml")}, 0, string(expectedJsonOutput), ""},
+		{"exitErrorFlagNone", []string{clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled, "-e"}, 0, "", ""},
+		{"exitErrorFlagFound", []string{clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled, "-e", "-f=" + filepath.Join(FIXTURES_DIR, "deployment-v1beta1.yaml")}, 200, "", ""},
+		{"version short flag set", []string{"-v"}, 0, "", ""},
+		{"version long flag set", []string{"--version"}, 0, "", ""},
+		{"empty text output", []string{clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled}, 0, "", ""},
+		{"empty json output", []string{"-o=json", clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled}, 0, "[]\n", ""},
+		{"json-file", []string{"-o=json", clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled, "-f=" + filepath.Join(FIXTURES_DIR, "deployment-v1beta1.yaml")}, 0, "", filepath.Join(tmpDir, "json-file.out")},
+		{"text-file", []string{"-o=json", clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled, "-f=" + filepath.Join(FIXTURES_DIR, "deployment-v1beta1.yaml")}, 0, "", filepath.Join(tmpDir, "text-file.out")},
+		{"json-stdout", []string{"-o=json", clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled, "-f=" + filepath.Join(FIXTURES_DIR, "deployment-v1beta1.yaml")}, 0, string(expectedJsonOutput), "-"},
+		{"error-bad-file", []string{clusterFlagDisabled, helm2FlagDisabled, helm3FlagDisabled}, 1, "", "/this/dir/is/unlikely/to/exist"},
 	}
 
 	if os.Getenv("TEST_EXIT_CODE") == "1" {
@@ -135,6 +147,9 @@ func TestMainExitCodes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var ee *exec.ExitError
 
+			if tc.outFileName != "" {
+				tc.args = append(tc.args, "-O="+tc.outFileName)
+			}
 			base64Args, _ := encodeBase64(tc.args)
 
 			cmd := exec.Command(os.Args[0], "-test.run=TestMainExitCodes")
@@ -161,6 +176,13 @@ func TestMainExitCodes(t *testing.T) {
 			if tc.expected == 0 && err == nil && tc.stdout != string(out) {
 				t.Fatalf("expected to get stdout as %s, instead got %s", tc.stdout, out)
 			}
+
+			if tc.expected == 0 && err == nil && tc.outFileName != "" && tc.outFileName != "-" {
+				if fs, err := os.Stat(tc.outFileName); err != nil || fs.Size() == 0 {
+					t.Fatalf("expected non-empty outputdile: %s, got error: %v", tc.outFileName, err)
+				}
+			}
+
 		})
 	}
 }
@@ -232,4 +254,33 @@ func decodeBase64(dst *[]string, encoded string) error {
 	jsonDec := json.NewDecoder(base64Dec)
 
 	return jsonDec.Decode(dst)
+}
+
+func Test_outputResults(t *testing.T) {
+	testVersion, _ := judge.NewVersion("4.5.6")
+	testResults := []judge.Result{{"name", "ns", "kind",
+		"1.2.3", "rs", "rep", testVersion}}
+
+	type args struct {
+		results    []judge.Result
+		outputType string
+		outputFile string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"good", args{testResults, "text", "-"}, false},
+		{"bad-new-printer-type", args{testResults, "unknown", "-"}, true},
+		{"bad-new-printer-file", args{testResults, "text", "/unlikely/to/exist/dir"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := outputResults(tt.args.results, tt.args.outputType, tt.args.outputFile); (err != nil) != tt.wantErr {
+				t.Errorf("unexpected error - got: %v, wantErr: %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -161,3 +161,24 @@ func TestContext(t *testing.T) {
 		}
 	}
 }
+
+func Test_validateOutputFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"does-not-exist", "/this/directory/is/unlikely/to/exist", true},
+		{"relative", "my.log", false},
+		{"absolute", "/my.log", false},
+		{"stdout", "-", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateOutputFile(tt.arg); (err != nil) != tt.wantErr {
+				t.Errorf("expected error = %v, got %v instead", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -2,25 +2,101 @@ package printer
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/doitintl/kube-no-trouble/pkg/judge"
 )
 
-func TestJsonPopulateOutput(t *testing.T) {
-	printer := &jsonPrinter{}
-	output, err := printer.populateOutput(testInput)
-
+func Test_newJSONPrinter(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "kubent-tests-")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tests := []struct {
+		name           string
+		outputFileName string
+		wantErr        bool
+	}{
+		{"good-stdout", "-", false},
+		{"good-file", tmpFile.Name(), false},
+		{"bad-empty", "", true},
 	}
 
-	var j []judge.Result
-	err = json.Unmarshal([]byte(output), &j)
-	if err != nil {
-		t.Fatal(err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newJSONPrinter(tt.outputFileName)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("unexpected error: %v, expected error: %v", err, tt.wantErr)
+			}
+
+			if err != nil && got != nil {
+				t.Errorf("expected nil in case of an error, got %v", got)
+			}
+		})
 	}
-	if len(j) != len(testInput) {
-		t.Error("wrong number of results")
+}
+
+func Test_jsonPrinter_Print(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "kubent-tests-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	c := &jsonPrinter{
+		commonPrinter: &commonPrinter{tmpFile},
+	}
+
+	version, _ := judge.NewVersion("1.2.3")
+	results := []judge.Result{{"Name", "Namespace", "Kind", "1.2.3", "Test", "4.5.6", version}}
+
+	if err := c.Print(results); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tmpFile.Seek(0, 0)
+
+	var readResults []judge.Result
+	readBytes, err := ioutil.ReadAll(tmpFile)
+	if err != nil {
+		t.Fatalf("unexpected error reading back the file: %v", err)
+	}
+	if err := json.Unmarshal(readBytes, &readResults); err != nil {
+		t.Fatalf("unexpected error unmarshalling the previously written file: %v", err)
+	}
+	if !reflect.DeepEqual(readResults, results) {
+		t.Fatalf("written and read result do not seem to be equal")
+	}
+}
+
+func Test_jsonPrinter_Close(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "kubent-tests-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tests := []struct {
+		name       string
+		outputFile *os.File
+		wantErr    bool
+	}{
+		{"good-file", tmpFile, false},
+		{"bad-closed-file", tmpFile, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &jsonPrinter{
+				commonPrinter: &commonPrinter{tt.outputFile},
+			}
+			if err := c.Close(); (err != nil) != tt.wantErr {
+				t.Errorf("Unexpected error - got: %v, expected error: %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -2,31 +2,75 @@ package printer
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/doitintl/kube-no-trouble/pkg/judge"
 )
 
-var printers = map[string]func() Printer{
+var printers = map[string]func(string) (Printer, error){
 	"json": newJSONPrinter,
 	"text": newTextPrinter,
 }
 
 type Printer interface {
 	Print([]judge.Result) error
+	Close() error
 }
 
-func NewPrinter(choice string) (Printer, error) {
+type commonPrinter struct {
+	outputFile *os.File
+}
+
+// newCommonPrinter creates new printer that prints to given output file
+func newCommonPrinter(outputFileName string) (*commonPrinter, error) {
+	outputFile, err := ensureOutputFileExists(outputFileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure output device: %v", err)
+	}
+
+	return &commonPrinter{
+		outputFile: outputFile,
+	}, nil
+}
+
+// NewPrinter creates new printer of given type that prints to given output file
+func NewPrinter(choice string, outputFileName string) (Printer, error) {
 	printer, err := ParsePrinter(choice)
 	if err != nil {
 		return nil, err
 	}
-	return printer(), nil
+	return printer(outputFileName)
 }
 
-func ParsePrinter(choice string) (func() Printer, error) {
+// Close will free resources used by the printer
+func (c *commonPrinter) Close() error {
+	if c.outputFile.Name() != os.Stdout.Name() {
+		if err := c.outputFile.Close(); err != nil {
+			return fmt.Errorf("failed to close output file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func ParsePrinter(choice string) (func(string) (Printer, error), error) {
 	printer, exists := printers[choice]
 	if !exists {
 		return nil, fmt.Errorf("unknown printer type %s", choice)
 	}
 	return printer, nil
+}
+
+// ensureOutputFileExists will open file for writing, or create one if non-existent
+func ensureOutputFileExists(fileName string) (*os.File, error) {
+	if fileName == "-" {
+		return os.Stdout, nil
+	}
+
+	of, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create/open output file %s: %w", fileName, err)
+	}
+
+	return of, nil
 }

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -1,23 +1,25 @@
 package printer
 
 import (
+	"reflect"
 	"testing"
 )
 
-func TestParsePrinters(t *testing.T) {
+func TestParsePrinter(t *testing.T) {
 	for k, v := range printers {
-		printer, err := NewPrinter(k)
+		p, err := ParsePrinter(k)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("failed to parse printer %s: %v", k, err)
 		}
-		if printer != v() {
-			t.Fatal("Should be a valid printer")
+
+		if reflect.ValueOf(p).Pointer() != reflect.ValueOf(v).Pointer() {
+			t.Fatalf("expected to get function %p, got %p instead", p, p)
 		}
 	}
 }
 
-func TestInvalidStringForParsePrinters(t *testing.T) {
-	_, err := NewPrinter("BAD")
+func TestParsePrinterInvalid(t *testing.T) {
+	_, err := ParsePrinter("BAD")
 	if err == nil {
 		t.Fatal(err)
 	}

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -1,6 +1,8 @@
 package printer
 
 import (
+	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -21,6 +23,151 @@ func TestParsePrinter(t *testing.T) {
 func TestParsePrinterInvalid(t *testing.T) {
 	_, err := ParsePrinter("BAD")
 	if err == nil {
-		t.Fatal(err)
+		t.Fatalf("expected ParsePrinter to fail with unimplemented type")
+	}
+}
+
+func TestNewPrinter(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "kubent-tests-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tests := []struct {
+		name              string
+		argChoice         string
+		argOutputFileName string
+		wantErr           bool
+		want              Printer
+	}{
+		{"good", "json", "-", false, &jsonPrinter{&commonPrinter{}}},
+		{"good-file", "json", tmpFile.Name(), false, &jsonPrinter{&commonPrinter{}}},
+		{"invalid", "xxx", "", true, nil},
+		{"invalid-out", "json", "/not/likely/to/exist", true, nil},
+		{"empty", "", "-", true, nil},
+		{"empty-out", "json", "", true, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewPrinter(tt.argChoice, tt.argOutputFileName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unexpected error - got: %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if reflect.TypeOf(got) != reflect.TypeOf(tt.want) {
+				t.Errorf("unexpected result - got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_newCommonPrinter(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "kubent-tests-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tests := []struct {
+		name              string
+		argOutputFileName string
+		wantErr           bool
+	}{
+		{"good-file", tmpFile.Name(), false},
+		{"good-stdout", "-", false},
+		{"bad-empty", "", true},
+		{"bad-path", "/this/is/unlikely/to/exist", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newCommonPrinter(tt.argOutputFileName)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("unexpected error - got: %v, wantErr: %v", err, tt.wantErr)
+			}
+
+			if err != nil && got != nil {
+				t.Fatalf("expected nil return in case of an error, got %v", got)
+			}
+
+			if !tt.wantErr {
+				defer got.Close()
+				if (tt.argOutputFileName != "-" && got.outputFile.Name() != tt.argOutputFileName) ||
+					tt.argOutputFileName == "-" && got.outputFile.Name() != os.Stdout.Name() {
+					t.Errorf("unexpected file name- got: %s, want: %s", got.outputFile.Name(), tt.argOutputFileName)
+				}
+			}
+		})
+	}
+}
+
+func Test_ensureOutputFileExists(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "kubent-tests-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		argsFileName string
+		wantErr      bool
+	}{
+		{"stdout", "-", false},
+		{"path", tmpFile.Name(), false},
+		{"bad-dir", "/unlikely/to/exist/directory/my.log", true},
+		{"bad-empty", "", true},
+	}
+	defer os.Remove(tmpFile.Name())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ensureOutputFileExists(tt.argsFileName)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("unexpected error - got: %v, wantErr: %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				if got != nil {
+					t.Fatalf("expected nil return in case of an error, got %v", got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("unexpected nil return, got %v", got)
+				}
+				if got.Name() != tt.argsFileName && tt.argsFileName != "-" ||
+					tt.argsFileName == "-" && got.Name() != os.Stdout.Name() {
+					t.Fatalf("expected os.File with Name: %s, got: %s", tt.argsFileName, got.Name())
+				}
+			}
+		})
+	}
+}
+
+func Test_commonPrinter_Close(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "kubent-tests-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tests := []struct {
+		name       string
+		outputFile *os.File
+		wantErr    bool
+	}{
+		{"good-file", tmpFile, false},
+		{"good-stdout", os.Stdout, false},
+		{"bad-closed-file", tmpFile, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &commonPrinter{
+				outputFile: tt.outputFile,
+			}
+			if err := c.Close(); (err != nil) != tt.wantErr {
+				t.Errorf("Unexpected error - got: %v, expected error: %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/pkg/printer/text.go
+++ b/pkg/printer/text.go
@@ -2,7 +2,6 @@ package printer
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -11,10 +10,24 @@ import (
 )
 
 type textPrinter struct {
+	*commonPrinter
 }
 
-func newTextPrinter() Printer {
-	return &textPrinter{}
+// newTextPrinter creates new text printer that prints to given output file
+func newTextPrinter(outputFileName string) (Printer, error) {
+	cp, err := newCommonPrinter(outputFileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new common printer: %w", err)
+	}
+
+	return &textPrinter{
+		commonPrinter: cp,
+	}, nil
+}
+
+// Close will free resources used by the printer
+func (c *textPrinter) Close() error {
+	return c.commonPrinter.Close()
 }
 
 func (c *textPrinter) Print(results []judge.Result) error {
@@ -33,7 +46,7 @@ func (c *textPrinter) Print(results []judge.Result) error {
 	})
 
 	ruleSet := ""
-	w := tabwriter.NewWriter(os.Stdout, 10, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(c.commonPrinter.outputFile, 10, 0, 3, ' ', 0)
 
 	for _, r := range results {
 		if ruleSet != r.RuleSet {

--- a/pkg/printer/text_test.go
+++ b/pkg/printer/text_test.go
@@ -1,0 +1,90 @@
+package printer
+
+import (
+	"github.com/doitintl/kube-no-trouble/pkg/judge"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func Test_newTextPrinter(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "kubent-tests-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tests := []struct {
+		name           string
+		outputFileName string
+		wantErr        bool
+	}{
+		{"good-stdout", "-", false},
+		{"good-file", tmpFile.Name(), false},
+		{"bad-empty", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newTextPrinter(tt.outputFileName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Unexpected error %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil && got != nil {
+				t.Errorf("expected nil in case of an error, got %v", got)
+			}
+		})
+	}
+}
+
+func Test_textPrinter_Print(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "kubent-tests-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tp := &textPrinter{
+		commonPrinter: &commonPrinter{tmpFile},
+	}
+
+	version, _ := judge.NewVersion("1.2.3")
+	results := []judge.Result{{"Name", "Namespace", "Kind", "1.2.3", "Test", "4.5.6", version}}
+
+	if err := tp.Print(results); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fi, _ := tmpFile.Stat()
+	if fi.Size() == 0 {
+		t.Fatalf("expected non-zero size output file: %v", err)
+	}
+}
+
+func Test_textPrinter_Close(t *testing.T) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "kubent-tests-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tests := []struct {
+		name       string
+		outputFile *os.File
+		wantErr    bool
+	}{
+		{"good-file", tmpFile, false},
+		{"bad-closed-file", tmpFile, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &textPrinter{
+				commonPrinter: &commonPrinter{tt.outputFile},
+			}
+			if err := c.Close(); (err != nil) != tt.wantErr {
+				t.Errorf("Unexpected error - got: %v, expected error: %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for `-O` flag to configure output to a file to main binary and all the existing printers (json, text).

Related changes introduced:
- Increased test coverage for the common code and existing printers in the `printer` package
- Refactored Main tests to pass arguments via env variable, this was required to maintain consistency between runs (tmp dir)


Fixes #304

_Sonar CLoud complains about test func naming with underscores (which are generated by Goland and questionably a standard for unexported func tests in Go) and some repeated strings all in tests. I plan to ignore it... in the longer term, we should really get to enabling some linters in a way that makes sense), the SC is getting annoying._