### PR TITLE
fix: Collect Ingress via v1 API

### DIFF
--- a/fixtures/fake-ingress-v1beta1-with-annotation.yaml
+++ b/fixtures/fake-ingress-v1beta1-with-annotation.yaml
@@ -1,7 +1,7 @@
 # fake client resource are a bit special
 # apiVersion need to match versions we're collection, i.e. apps/v1
 # true version is taken from kubectl.kubernetes.io/last-applied-configuration
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -15,7 +15,7 @@ metadata:
   name: test-ingress
   namespace: default
   resourceVersion: "676987"
-  selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/test-ingress
+  selfLink: /apis/networking.k8s.io/v1/namespaces/default/ingresses/test-ingress
   uid: eefa4af8-cde3-4dc5-b1a4-0f6008d67273
 spec:
   rules:

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -76,7 +76,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"},
 		schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
 		schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "podsecuritypolicies"},
-		schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "ingresses"},
+		schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 		schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingressclasses"},
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csidrivers"},
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csinodes"},


### PR DESCRIPTION
Fixes #364

Use the v1 API to collect Ingress objects to avoid tripping metrics for use of deprecated APIs