### PR TITLE
refactor: use a struct instead of map[string]interface{}

### DIFF
--- a/cmd/kubent/main.go
+++ b/cmd/kubent/main.go
@@ -33,8 +33,8 @@ func generateUserAgent() string {
 	return fmt.Sprintf("kubent (%s/%s)", version, gitSha)
 }
 
-func getCollectors(collectors []collector.Collector) []map[string]interface{} {
-	var inputs []map[string]interface{}
+func getCollectors(collectors []collector.Collector) []collector.MetaOject {
+	var inputs []collector.MetaOject
 	for _, c := range collectors {
 		rs, err := c.Get()
 		if err != nil {
@@ -81,7 +81,7 @@ func initCollectors(config *config.Config) []collector.Collector {
 	return collectors
 }
 
-func getServerVersion(cv *judge.Version, collectors []collector.Collector) (*judge.Version, error) {
+func getServerVersion(cv *collector.Version, collectors []collector.Collector) (*collector.Version, error) {
 	if cv == nil {
 		for _, c := range collectors {
 			if versionCol, ok := c.(collector.VersionCollector); ok {
@@ -121,6 +121,9 @@ func main() {
 	initCollectors := initCollectors(config)
 
 	config.TargetVersion, err = getServerVersion(config.TargetVersion, initCollectors)
+	if err != nil {
+		log.Warn().Msgf("failed to get server version: %s", err)
+	}
 	if config.TargetVersion != nil {
 		log.Info().Msgf("Target K8s version is %s", config.TargetVersion.String())
 	}

--- a/cmd/kubent/main.go
+++ b/cmd/kubent/main.go
@@ -27,6 +27,7 @@ const (
 	EXIT_CODE_SUCCESS      = 0
 	EXIT_CODE_FAIL_GENERIC = 1
 	EXIT_CODE_FOUND_ISSUES = 200
+	LastAppliedConfig      = "kubectl.kubernetes.io/last-applied-configuration"
 )
 
 func generateUserAgent() string {
@@ -110,6 +111,10 @@ func main() {
 	if config.KubentVersion {
 		log.Info().Msgf("version %s (git sha %s)", version, gitSha)
 		os.Exit(EXIT_CODE_SUCCESS)
+	}
+
+	if config.LastAppliedConfig {
+		config.AdditionalAnnotations = append(config.AdditionalAnnotations, LastAppliedConfig)
 	}
 
 	zerolog.SetGlobalLevel(zerolog.Level(config.LogLevel))

--- a/cmd/kubent/main_test.go
+++ b/cmd/kubent/main_test.go
@@ -231,7 +231,7 @@ func TestGetServerVersion(t *testing.T) {
 		t.Errorf("Failed to get version with error: %s", err)
 	}
 
-	fakeVersion, _ := judge.NewVersion(collector.FAKE_VERSION)
+	fakeVersion, _ := collector.NewVersion(collector.FAKE_VERSION)
 	if version.Compare(fakeVersion.Version) != 0 {
 		t.Errorf("Expected %s version to be detected, instead got: %s", fakeVersion.String(), version.String())
 	}
@@ -257,7 +257,7 @@ func decodeBase64(dst *[]string, encoded string) error {
 }
 
 func Test_outputResults(t *testing.T) {
-	testVersion, _ := judge.NewVersion("4.5.6")
+	testVersion, _ := collector.NewVersion("4.5.6")
 	testResults := []judge.Result{{"name", "ns", "kind",
 		"1.2.3", "rs", "rep", testVersion}}
 

--- a/fixtures/volumesnapshotcontent-v1beta1.yaml
+++ b/fixtures/volumesnapshotcontent-v1beta1.yaml
@@ -3,7 +3,7 @@ kind: VolumeSnapshotContent
 metadata:
   name: new-snapshot-content-test
   annotations:
-    - snapshot.storage.kubernetes.io/allowVolumeModeChange: "true"
+    snapshot.storage.kubernetes.io/allowVolumeModeChange: "true"
 spec:
   deletionPolicy: Delete
   driver: hostpath.csi.k8s.io

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	helm.sh/helm/v3 v3.1.3
 	k8s.io/apimachinery v0.17.13
 	k8s.io/client-go v0.17.13
+	sigs.k8s.io/yaml v1.2.0
 )
 
 require (
@@ -66,5 +67,4 @@ require (
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 // indirect
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 // indirect
-	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/pkg/collector/cluster_test.go
+++ b/pkg/collector/cluster_test.go
@@ -82,7 +82,7 @@ func TestClusterCollectorGetFake(t *testing.T) {
 		{
 			name:     "withoutAnnotation",
 			input:    []string{"fake-deployment-v1beta1-no-annotation.yaml"},
-			expected: 0,
+			expected: 1,
 		},
 		{
 			name:     "one",
@@ -97,7 +97,7 @@ func TestClusterCollectorGetFake(t *testing.T) {
 		{
 			name:     "mixed",
 			input:    []string{"fake-deployment-v1beta1-no-annotation.yaml", "fake-ingress-v1beta1-with-annotation.yaml"},
-			expected: 1,
+			expected: 2,
 		},
 		{
 			name:                  "kappAnnotation",
@@ -116,6 +116,9 @@ func TestClusterCollectorGetFake(t *testing.T) {
 				obj := &unstructured.Unstructured{}
 
 				input, err := ioutil.ReadFile(filepath.Join(FIXTURES_DIR, f))
+				if err != nil {
+					t.Errorf("failed to read file: %s", err)
+				}
 				dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 				_, _, err = dec.Decode(input, nil, obj)
 				if err != nil {

--- a/pkg/collector/cluster_test.go
+++ b/pkg/collector/cluster_test.go
@@ -103,7 +103,7 @@ func TestClusterCollectorGetFake(t *testing.T) {
 			name:                  "kappAnnotation",
 			input:                 []string{"fake-deployment-v1beta1-with-kapp-annotation.yaml"},
 			additionalAnnotations: []string{"kapp.k14s.io/original"},
-			expected:              1,
+			expected:              2,
 		},
 	}
 
@@ -147,73 +147,6 @@ func TestClusterCollectorGetFake(t *testing.T) {
 			}
 			if len(result) != tc.expected {
 				t.Errorf("expected to receive %d, received %d resources", tc.expected, len(result))
-			}
-		})
-	}
-}
-
-func TestClusterCollector_getLastAppliedConfig(t *testing.T) {
-	tests := []struct {
-		name                string
-		c                   *ClusterCollector
-		resourceAnnotations map[string]string
-		wantManifest        string
-		wantOk              bool
-	}{
-		{
-			name: "Default annotation",
-			c:    &ClusterCollector{},
-			resourceAnnotations: map[string]string{
-				"kubectl.kubernetes.io/last-applied-configuration": "Some config",
-				"another-annotation": "Bla",
-			},
-			wantManifest: "Some config",
-			wantOk:       true,
-		},
-		{
-			name: "Try kubectl annotation first",
-			c: &ClusterCollector{
-				additionalAnnotations: []string{"kapp.k14s.io/original"},
-			},
-			resourceAnnotations: map[string]string{
-				"kubectl.kubernetes.io/last-applied-configuration": "Some config",
-				"kapp.k14s.io/original":                            "Kapp config",
-				"another-annotation":                               "Bla",
-			},
-			wantManifest: "Some config",
-			wantOk:       true,
-		},
-		{
-			name: "Use additional annotation",
-			c: &ClusterCollector{
-				additionalAnnotations: []string{"kapp.k14s.io/original"},
-			},
-			resourceAnnotations: map[string]string{
-				"kapp.k14s.io/original": "Kapp config",
-				"another-annotation":    "Bla",
-			},
-			wantManifest: "Kapp config",
-			wantOk:       true,
-		},
-		{
-			name: "No annotation found",
-			c: &ClusterCollector{
-				additionalAnnotations: []string{},
-			},
-			resourceAnnotations: map[string]string{
-				"kapp.k14s.io/original": "Kapp config",
-				"another-annotation":    "Bla",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			manifest, ok := tt.c.getLastAppliedConfig(tt.resourceAnnotations)
-			if manifest != tt.wantManifest {
-				t.Errorf("ClusterCollector.getLastAppliedConfig() got = %v, want %v", manifest, tt.wantManifest)
-			}
-			if ok != tt.wantOk {
-				t.Errorf("ClusterCollector.getLastAppliedConfig() got1 = %v, want %v", ok, tt.wantOk)
 			}
 		})
 	}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,16 +1,21 @@
 package collector
 
 import (
-	"github.com/doitintl/kube-no-trouble/pkg/judge"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type MetaOject struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
 type Collector interface {
-	Get() ([]map[string]interface{}, error)
+	Get() ([]MetaOject, error)
 	Name() string
 }
 
 type VersionCollector interface {
-	GetServerVersion() (*judge.Version, error)
+	GetServerVersion() (*Version, error)
 }
 
 type commonCollector struct {

--- a/pkg/collector/fake.go
+++ b/pkg/collector/fake.go
@@ -1,9 +1,5 @@
 package collector
 
-import (
-	"github.com/doitintl/kube-no-trouble/pkg/judge"
-)
-
 const (
 	FAKE_VERSION        = "1.2.3"
 	FAKE_COLLECTOR_NAME = "Fake"
@@ -13,8 +9,8 @@ type fakeCollector struct {
 	*commonCollector
 }
 
-func (c *fakeCollector) Get() ([]map[string]interface{}, error) {
-	return []map[string]interface{}{}, nil
+func (c *fakeCollector) Get() ([]MetaOject, error) {
+	return []MetaOject{}, nil
 }
 
 func NewFakeCollector() *fakeCollector {
@@ -23,8 +19,8 @@ func NewFakeCollector() *fakeCollector {
 	}
 }
 
-func (c *fakeCollector) GetServerVersion() (*judge.Version, error) {
-	version, err := judge.NewVersion(FAKE_VERSION)
+func (c *fakeCollector) GetServerVersion() (*Version, error) {
+	version, err := NewVersion(FAKE_VERSION)
 
 	return version, err
 }

--- a/pkg/collector/file_test.go
+++ b/pkg/collector/file_test.go
@@ -52,9 +52,9 @@ func TestFileCollectorGet(t *testing.T) {
 				t.Errorf("Expected to get %d, got %d", len(tc.expected), len(manifests))
 			}
 
-			for i, _ := range manifests {
-				if manifests[i]["kind"] != tc.expected[i] {
-					t.Errorf("Expected to get %s, instead got: %s", tc.expected[i], manifests[i]["kind"])
+			for i := range manifests {
+				if manifests[i].Kind != tc.expected[i] {
+					t.Errorf("Expected to get %s, instead got: %s", tc.expected[i], manifests[i].Kind)
 				}
 			}
 		})
@@ -75,7 +75,7 @@ func TestFileCollectorGetUnknown(t *testing.T) {
 	result, _ := c.Get()
 
 	if len(result) != 0 {
-		t.Errorf("Expected empty result instead got %s", result)
+		t.Errorf("Expected empty result instead got %v", result)
 	}
 }
 

--- a/pkg/collector/helm.go
+++ b/pkg/collector/helm.go
@@ -3,16 +3,16 @@ package collector
 import (
 	"fmt"
 
-	"github.com/ghodss/yaml"
 	"helm.sh/helm/v3/pkg/releaseutil"
+	"sigs.k8s.io/yaml"
 )
 
-func parseManifests(manifest string, defaultNamespace string) ([]map[string]interface{}, error) {
-	var results []map[string]interface{}
+func parseManifests(manifest string, defaultNamespace string) ([]MetaOject, error) {
+	var results []MetaOject
 
 	manifests := releaseutil.SplitManifests(manifest)
 	for i, m := range manifests {
-		var manifest map[string]interface{}
+		var manifest MetaOject
 
 		err := yaml.Unmarshal([]byte(m), &manifest)
 		if err != nil {
@@ -28,14 +28,9 @@ func parseManifests(manifest string, defaultNamespace string) ([]map[string]inte
 	return results, nil
 }
 
-func fixNamespace(manifest *map[string]interface{}, defaultNamespace string) {
+func fixNamespace(manifest *MetaOject, defaultNamespace string) {
 	// Default to the release namespace if the manifest doesn't have the namespace set
-	if meta, ok := (*manifest)["metadata"]; ok {
-		switch v := meta.(type) {
-		case map[string]interface{}:
-			if val, ok := v["namespace"]; !ok || val == nil {
-				v["namespace"] = defaultNamespace
-			}
-		}
+	if manifest.Namespace == "" {
+		manifest.Namespace = defaultNamespace
 	}
 }

--- a/pkg/collector/helm2.go
+++ b/pkg/collector/helm2.go
@@ -52,7 +52,7 @@ func NewHelmV2Collector(opts *HelmV2Opts, userAgent string) (*HelmV2Collector, e
 	return collector, nil
 }
 
-func (c *HelmV2Collector) Get() ([]map[string]interface{}, error) {
+func (c *HelmV2Collector) Get() ([]MetaOject, error) {
 	releases, err := c.secretsStore.ListDeployed()
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (c *HelmV2Collector) Get() ([]map[string]interface{}, error) {
 
 	releases = append(releases, releasesConfig...)
 
-	var results []map[string]interface{}
+	var results []MetaOject
 
 	for _, r := range releases {
 		if manifests, err := parseManifests(r.Manifest, r.Namespace); err != nil {

--- a/pkg/collector/helm3.go
+++ b/pkg/collector/helm3.go
@@ -51,7 +51,7 @@ func NewHelmV3Collector(opts *HelmV3Opts, userAgent string) (*HelmV3Collector, e
 	return collector, nil
 }
 
-func (c *HelmV3Collector) Get() ([]map[string]interface{}, error) {
+func (c *HelmV3Collector) Get() ([]MetaOject, error) {
 	releases, err := c.secretsStore.ListDeployed()
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (c *HelmV3Collector) Get() ([]map[string]interface{}, error) {
 
 	releases = append(releases, releasesConfig...)
 
-	var results []map[string]interface{}
+	var results []MetaOject
 
 	for _, r := range releases {
 		if manifests, err := parseManifests(r.Manifest, r.Namespace); err != nil {

--- a/pkg/collector/helm_test.go
+++ b/pkg/collector/helm_test.go
@@ -1,8 +1,9 @@
 package collector
 
 import (
-	"reflect"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSplitManifests(t *testing.T) {
@@ -41,19 +42,15 @@ func TestSplitManifests(t *testing.T) {
 func TestFixNamespace(t *testing.T) {
 	testCases := []struct {
 		name     string
-		input    map[string]interface{} // manifest
-		expected string                 // kinds of objects
+		input    MetaOject // manifest
+		expected string    // kinds of objects
 	}{
 		{"present",
-			map[string]interface{}{"metadata": map[string]interface{}{"namespace": "some-namespace"}},
+			MetaOject{ObjectMeta: metav1.ObjectMeta{Namespace: "some-namespace"}},
 			"some-namespace",
 		},
 		{"missing",
-			map[string]interface{}{"metadata": map[string]interface{}{}},
-			"default-namespace",
-		},
-		{"nil",
-			map[string]interface{}{"metadata": map[string]interface{}{"namespace": nil}},
+			MetaOject{},
 			"default-namespace",
 		},
 	}
@@ -63,20 +60,7 @@ func TestFixNamespace(t *testing.T) {
 
 			fixNamespace(&tc.input, tc.expected)
 
-			meta, ok := tc.input["metadata"]
-			if !ok {
-				t.Fatalf("Expected fixed manifest to have metadata key")
-			}
-
-			expectedType := "map[string]interface {}"
-			if reflect.TypeOf(meta).String() != expectedType {
-				t.Fatalf("Expected metadata type to be %s, instead got: %T", expectedType, meta)
-			}
-
-			actual, ok := meta.(map[string]interface{})["namespace"]
-			if !ok {
-				t.Fatalf("Expected fixed manifest to have metadata.namespace key")
-			}
+			actual := tc.input.ObjectMeta.Namespace
 
 			if actual != tc.expected {
 				t.Fatalf("Expected namespace to be: %s, instead got: %s", tc.expected, actual)

--- a/pkg/collector/kube.go
+++ b/pkg/collector/kube.go
@@ -6,8 +6,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/doitintl/kube-no-trouble/pkg/judge"
 )
 
 type kubeCollector struct {
@@ -67,13 +65,13 @@ func newClientRestConfig(kubeconfig string, kubecontext string, inClusterFn func
 	return restConfig, nil
 }
 
-func (c *kubeCollector) GetServerVersion() (*judge.Version, error) {
+func (c *kubeCollector) GetServerVersion() (*Version, error) {
 	version, err := c.discoveryClient.ServerVersion()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server version %w", err)
 	}
 
-	return judge.NewVersion(version.String())
+	return NewVersion(version.String())
 }
 
 func (c *kubeCollector) GetRestConfig() *rest.Config {

--- a/pkg/collector/version.go
+++ b/pkg/collector/version.go
@@ -1,7 +1,8 @@
-package judge
+package collector
 
 import (
 	"fmt"
+
 	goversion "github.com/hashicorp/go-version"
 )
 

--- a/pkg/collector/version_test.go
+++ b/pkg/collector/version_test.go
@@ -2,8 +2,14 @@ package collector
 
 import (
 	"encoding/json"
-	goversion "github.com/hashicorp/go-version"
 	"testing"
+
+	goversion "github.com/hashicorp/go-version"
+)
+
+const (
+	defaultOutput   = "expected: %q, got: %q"
+	expectedSuccess = "expected to succeed, failed instead: %v"
 )
 
 func TestVersionMarshalText(t *testing.T) {
@@ -20,7 +26,7 @@ func TestVersionMarshalText(t *testing.T) {
 		t.Fatal(err)
 	}
 	if string(actual) != v {
-		t.Fatalf("expected: %q, got: %q", v, actual)
+		t.Fatalf(defaultOutput, v, actual)
 	}
 }
 
@@ -38,7 +44,7 @@ func TestVersionString(t *testing.T) {
 		t.Fatal(err)
 	}
 	if actual != v {
-		t.Fatalf("expected: %q, got: %q", v, actual)
+		t.Fatalf(defaultOutput, v, actual)
 	}
 }
 
@@ -49,7 +55,7 @@ func TestVersionStringNil(t *testing.T) {
 	actual := version.String()
 
 	if actual != expected {
-		t.Fatalf("expected: %q, got: %q", expected, actual)
+		t.Fatalf(defaultOutput, expected, actual)
 	}
 }
 
@@ -62,7 +68,7 @@ func TestNewVersion(t *testing.T) {
 	}
 
 	if v.String() != expected {
-		t.Fatalf("expected: %q, got: %q", expected, v.String())
+		t.Fatalf(defaultOutput, expected, v.String())
 	}
 }
 
@@ -81,11 +87,11 @@ func TestVersionSet(t *testing.T) {
 
 	err := v.Set(expected)
 	if err != nil {
-		t.Fatalf("expected to succeed, failed instead: %v", err)
+		t.Fatalf(expectedSuccess, err)
 	}
 
 	if v.String() != expected {
-		t.Fatalf("expected: %q, got: %q", expected, v.String())
+		t.Fatalf(defaultOutput, expected, v.String())
 	}
 }
 
@@ -93,16 +99,16 @@ func TestVersionNewFromGoVersion(t *testing.T) {
 	expected := "1.2.3"
 	goVer, err := goversion.NewVersion(expected)
 	if err != nil {
-		t.Fatalf("expected to succeed, failed instead: %v", err)
+		t.Fatalf(expectedSuccess, err)
 	}
 
 	v, err := NewFromGoVersion(goVer)
 	if err != nil {
-		t.Fatalf("expected to succeed, failed instead: %v", err)
+		t.Fatalf(expectedSuccess, err)
 	}
 
 	if v.String() != expected {
-		t.Fatalf("expected: %q, got: %q", expected, v.String())
+		t.Fatalf(defaultOutput, expected, v.String())
 	}
 }
 
@@ -124,6 +130,6 @@ func TestVersionUnmarshalText(t *testing.T) {
 	}
 
 	if v.String() != expected {
-		t.Fatalf("expected: %q, got: %q", expected, v.String())
+		t.Fatalf(defaultOutput, expected, v.String())
 	}
 }

--- a/pkg/collector/version_test.go
+++ b/pkg/collector/version_test.go
@@ -1,4 +1,4 @@
-package judge
+package collector
 
 import (
 	"encoding/json"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	OutputFile            string
 	TargetVersion         *collector.Version
 	KubentVersion         bool
+	LastAppliedConfig     bool
 }
 
 func NewFromFlags() (*Config, error) {
@@ -53,6 +54,7 @@ func NewFromFlags() (*Config, error) {
 	flag.StringVarP(&config.OutputFile, "output-file", "O", "-", "output file, use - for stdout")
 	flag.VarP(&config.LogLevel, "log-level", "l", "set log level (trace, debug, info, warn, error, fatal, panic, disabled)")
 	flag.VarP(config.TargetVersion, "target-version", "t", "target K8s version in SemVer format (autodetected by default)")
+	flag.BoolVar(&config.LastAppliedConfig, "last-applied-config", true, "check the last applied configuration from kubectl")
 
 	flag.Parse()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/doitintl/kube-no-trouble/pkg/judge"
+	"github.com/doitintl/kube-no-trouble/pkg/collector"
 	"github.com/doitintl/kube-no-trouble/pkg/printer"
 
 	"github.com/rs/zerolog"
@@ -29,14 +29,14 @@ type Config struct {
 	LogLevel              ZeroLogLevel
 	Output                string
 	OutputFile            string
-	TargetVersion         *judge.Version
+	TargetVersion         *collector.Version
 	KubentVersion         bool
 }
 
 func NewFromFlags() (*Config, error) {
 	config := Config{
 		LogLevel:      ZeroLogLevel(zerolog.InfoLevel),
-		TargetVersion: &judge.Version{},
+		TargetVersion: &collector.Version{},
 	}
 
 	flag.StringSliceVarP(&config.AdditionalKinds, "additional-kind", "a", []string{}, "additional kinds of resources to report in Kind.version.group.com format")

--- a/pkg/judge/judge.go
+++ b/pkg/judge/judge.go
@@ -1,5 +1,7 @@
 package judge
 
+import "github.com/doitintl/kube-no-trouble/pkg/collector"
+
 type Result struct {
 	Name        string
 	Namespace   string
@@ -7,9 +9,9 @@ type Result struct {
 	ApiVersion  string
 	RuleSet     string
 	ReplaceWith string
-	Since       *Version
+	Since       *collector.Version
 }
 
 type Judge interface {
-	Eval([]map[string]interface{}) ([]Result, error)
+	Eval([]collector.MetaOject) ([]Result, error)
 }

--- a/pkg/judge/rego.go
+++ b/pkg/judge/rego.go
@@ -2,6 +2,8 @@ package judge
 
 import (
 	"context"
+
+	"github.com/doitintl/kube-no-trouble/pkg/collector"
 	"github.com/doitintl/kube-no-trouble/pkg/rules"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/rs/zerolog/log"
@@ -35,7 +37,7 @@ func NewRegoJudge(opts *RegoOpts, rules []rules.Rule) (*RegoJudge, error) {
 	return judge, nil
 }
 
-func (j *RegoJudge) Eval(input []map[string]interface{}) ([]Result, error) {
+func (j *RegoJudge) Eval(input []collector.MetaOject) ([]Result, error) {
 	ctx := context.Background()
 
 	log.Trace().Msgf("evaluating +%v", input)
@@ -51,7 +53,7 @@ func (j *RegoJudge) Eval(input []map[string]interface{}) ([]Result, error) {
 				m := i.(map[string]interface{})
 				log.Trace().Msgf("parsing +%v", m)
 
-				since, err := NewVersion(m["Since"].(string))
+				since, err := collector.NewVersion(m["Since"].(string))
 				if err != nil {
 					log.Debug().Msgf("Failed to parse version: %s", err)
 				}

--- a/pkg/judge/rego_test.go
+++ b/pkg/judge/rego_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/doitintl/kube-no-trouble/pkg/collector"
 	"github.com/doitintl/kube-no-trouble/pkg/rules"
 
 	"github.com/ghodss/yaml"
@@ -21,7 +22,7 @@ func TestNewRegoJudge(t *testing.T) {
 }
 
 func TestEvalEmpty(t *testing.T) {
-	inputs := []map[string]interface{}{}
+	inputs := []collector.MetaOject{}
 
 	judge, err := NewRegoJudge(&RegoOpts{}, []rules.Rule{})
 	if err != nil {
@@ -51,7 +52,7 @@ func TestEvalRules(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			var manifests []map[string]interface{}
+			var manifests []collector.MetaOject
 
 			for _, f := range tc.inputFiles {
 				var input []byte
@@ -62,7 +63,7 @@ func TestEvalRules(t *testing.T) {
 					t.Errorf("failed to read file %s: %v", f, err)
 				}
 
-				var manifest map[string]interface{}
+				var manifest collector.MetaOject
 				err = yaml.Unmarshal([]byte(input), &manifest)
 				if err != nil {
 					t.Errorf("failed to parse file %s: %v", f, err)

--- a/pkg/printer/filter.go
+++ b/pkg/printer/filter.go
@@ -1,10 +1,11 @@
 package printer
 
 import (
+	"github.com/doitintl/kube-no-trouble/pkg/collector"
 	"github.com/doitintl/kube-no-trouble/pkg/judge"
 )
 
-func FilterNonRelevantResults(results []judge.Result, tv *judge.Version) ([]judge.Result, error) {
+func FilterNonRelevantResults(results []judge.Result, tv *collector.Version) ([]judge.Result, error) {
 	if tv != nil {
 		filtered := []judge.Result{}
 

--- a/pkg/printer/filter_test.go
+++ b/pkg/printer/filter_test.go
@@ -3,11 +3,12 @@ package printer
 import (
 	"testing"
 
+	"github.com/doitintl/kube-no-trouble/pkg/collector"
 	"github.com/doitintl/kube-no-trouble/pkg/judge"
 )
 
-var testVersion1, _ = judge.NewVersion("1.1.1")
-var testVersion2, _ = judge.NewVersion("2.2.2")
+var testVersion1, _ = collector.NewVersion("1.1.1")
+var testVersion2, _ = collector.NewVersion("2.2.2")
 
 var testInput []judge.Result = []judge.Result{
 	{
@@ -40,7 +41,7 @@ var testInput []judge.Result = []judge.Result{
 }
 
 func TestFilterNonRelevantResults(t *testing.T) {
-	filterVersion, _ := judge.NewVersion("2.0.0")
+	filterVersion, _ := collector.NewVersion("2.0.0")
 
 	results, err := FilterNonRelevantResults(testInput[0:2], filterVersion)
 	if err != nil {
@@ -53,7 +54,7 @@ func TestFilterNonRelevantResults(t *testing.T) {
 }
 
 func TestFilterNonRelevantResultsEmpty(t *testing.T) {
-	filterVersion, _ := judge.NewVersion("2.0.0")
+	filterVersion, _ := collector.NewVersion("2.0.0")
 
 	var input []judge.Result = []judge.Result{}
 
@@ -68,7 +69,7 @@ func TestFilterNonRelevantResultsEmpty(t *testing.T) {
 }
 
 func TestFilterNonRelevantResultsWithNilVersion(t *testing.T) {
-	filterVersion, _ := judge.NewVersion("2.0.0")
+	filterVersion, _ := collector.NewVersion("2.0.0")
 
 	results, err := FilterNonRelevantResults(testInput[2:3], filterVersion)
 	if err != nil {
@@ -81,7 +82,7 @@ func TestFilterNonRelevantResultsWithNilVersion(t *testing.T) {
 }
 
 func TestFilterNonRelevantResultsNilTargetVersion(t *testing.T) {
-	var filterVersion *judge.Version
+	var filterVersion *collector.Version
 
 	results, err := FilterNonRelevantResults(testInput, filterVersion)
 	if err != nil {

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/doitintl/kube-no-trouble/pkg/collector"
 	"github.com/doitintl/kube-no-trouble/pkg/judge"
 )
 
@@ -52,7 +53,7 @@ func Test_jsonPrinter_Print(t *testing.T) {
 		commonPrinter: &commonPrinter{tmpFile},
 	}
 
-	version, _ := judge.NewVersion("1.2.3")
+	version, _ := collector.NewVersion("1.2.3")
 	results := []judge.Result{{"Name", "Namespace", "Kind", "1.2.3", "Test", "4.5.6", version}}
 
 	if err := c.Print(results); err != nil {

--- a/pkg/printer/text_test.go
+++ b/pkg/printer/text_test.go
@@ -1,10 +1,12 @@
 package printer
 
 import (
-	"github.com/doitintl/kube-no-trouble/pkg/judge"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/doitintl/kube-no-trouble/pkg/collector"
+	"github.com/doitintl/kube-no-trouble/pkg/judge"
 )
 
 func Test_newTextPrinter(t *testing.T) {
@@ -49,7 +51,7 @@ func Test_textPrinter_Print(t *testing.T) {
 		commonPrinter: &commonPrinter{tmpFile},
 	}
 
-	version, _ := judge.NewVersion("1.2.3")
+	version, _ := collector.NewVersion("1.2.3")
 	results := []judge.Result{{"Name", "Namespace", "Kind", "1.2.3", "Test", "4.5.6", version}}
 
 	if err := tp.Print(results); err != nil {

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -18,6 +18,9 @@ func TestFetchRules(t *testing.T) {
 		}
 		return nil
 	})
+	if err != nil {
+		t.Errorf("failed to read files: %s", err)
+	}
 
 	rules, err := FetchRegoRules([]schema.GroupVersionKind{})
 	if err != nil {
@@ -38,6 +41,9 @@ func TestFetchRulesWithAdditionalResources(t *testing.T) {
 		}
 		return nil
 	})
+	if err != nil {
+		t.Errorf("failed to read files: %s", err)
+	}
 
 	additionalKindsStr := []string{
 		"ManagedCertificate.v1.networking.gke.io",

--- a/test/helper_test.go
+++ b/test/helper_test.go
@@ -58,8 +58,8 @@ func testResourcesUsingFixtures(t *testing.T, testCases []resourceFixtureTestCas
 			}
 
 			for i := range manifests {
-				if manifests[i]["kind"] != tc.expectedKinds[i] {
-					t.Errorf("Expected to get %s, instead got: %s", tc.expectedKinds[i], manifests[i]["kind"])
+				if manifests[i].Kind != tc.expectedKinds[i] {
+					t.Errorf("Expected to get %s, instead got: %s", tc.expectedKinds[i], manifests[i].Kind)
 				}
 			}
 		})


### PR DESCRIPTION
* Use a `struct` instead of `map[string]interface{}`
* Use the actual object instead of the last applied configuration annotation

~~If you think checking the `kubectl` annotation is important, I can add it as an extra check but I do think we should check the actual object first~~
**update:** I've added a new flag to toggle checking the `kubectl` annotation

Note: I had to move `Version` from the `judge` package to the `collector` package to avoid cyclic dependencies, maybe version should be its own package?

I've tested a build from my branch against a real EKS cluster with version 1.23:

```console
$ ./bin/kubent-darwin-amd64  
8:06PM INF >>> Kube No Trouble `kubent` <<<
8:06PM INF version dev (git sha dev)
8:06PM INF Initializing collectors and retrieving data
8:06PM INF Target K8s version is 1.23.10-eks-15b7512
8:06PM INF Retrieved 930 resources from collector name=Cluster
8:06PM INF Retrieved 0 resources from collector name="Helm v2"
8:07PM INF Retrieved 157 resources from collector name="Helm v3"
8:07PM INF Loaded ruleset name=custom.rego.tmpl
8:07PM INF Loaded ruleset name=deprecated-1-16.rego
8:07PM INF Loaded ruleset name=deprecated-1-22.rego
8:07PM INF Loaded ruleset name=deprecated-1-25.rego
8:07PM INF Loaded ruleset name=deprecated-future.rego
__________________________________________________________________________________________
>>> Deprecated APIs removed in 1.25 <<<
------------------------------------------------------------------------------------------
KIND                  NAMESPACE     NAME                                        API_VERSION      REPLACE_WITH (SINCE)
PodDisruptionBudget   kube-system   cluster-autoscaler-aws-cluster-autoscaler   policy/v1beta1   policy/v1 (1.21.0)
PodDisruptionBudget   kube-system   ingress-nginx-controller                    policy/v1beta1   policy/v1 (1.21.0)
PodDisruptionBudget   kube-system   ingress-nginx-internal-controller           policy/v1beta1   policy/v1 (1.21.0)
PodDisruptionBudget   kyverno       kyverno                                     policy/v1beta1   policy/v1 (1.21.0)
PodSecurityPolicy     <undefined>   eks.privileged                              policy/v1beta1   <removed> (1.21.0)
PodSecurityPolicy     <undefined>   pl                                          policy/v1beta1   <removed> (1.21.0)
```