### PR TITLE
fix: Helm - only default to release namespace for namespaced resources

### DIFF
--- a/pkg/collector/helm2.go
+++ b/pkg/collector/helm2.go
@@ -68,7 +68,7 @@ func (c *HelmV2Collector) Get() ([]map[string]interface{}, error) {
 	var results []map[string]interface{}
 
 	for _, r := range releases {
-		if manifests, err := parseManifests(r.Manifest, r.Namespace); err != nil {
+		if manifests, err := parseManifests(r.Manifest, r.Namespace, c.discoveryClient); err != nil {
 			log.Warn().Msgf("failed to parse release %s/%s: %v", r.Namespace, r.Name, err)
 		} else {
 			results = append(results, manifests...)

--- a/pkg/collector/helm3.go
+++ b/pkg/collector/helm3.go
@@ -67,7 +67,7 @@ func (c *HelmV3Collector) Get() ([]map[string]interface{}, error) {
 	var results []map[string]interface{}
 
 	for _, r := range releases {
-		if manifests, err := parseManifests(r.Manifest, r.Namespace); err != nil {
+		if manifests, err := parseManifests(r.Manifest, r.Namespace, c.discoveryClient); err != nil {
 			log.Warn().Msgf("failed to parse release %s/%s: %v", r.Namespace, r.Name, err)
 		} else {
 			results = append(results, manifests...)

--- a/pkg/collector/helm_test.go
+++ b/pkg/collector/helm_test.go
@@ -1,9 +1,23 @@
 package collector
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"reflect"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
 )
+
+var FAKE_API_RESOURCES = &metav1.APIResourceList{
+	GroupVersion: "v1",
+	APIResources: []metav1.APIResource{
+		{Name: "pods", Namespaced: true, Kind: "Pod"},
+		{Name: "services", Namespaced: true, Kind: "Service"},
+		{Name: "namespaces", Namespaced: false, Kind: "Namespace"},
+	},
+}
 
 func TestSplitManifests(t *testing.T) {
 	testCases := []struct {
@@ -24,7 +38,8 @@ func TestSplitManifests(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			manifests, err := parseManifests(tc.input, "default")
+			fcs := fake.NewSimpleClientset()
+			manifests, err := parseManifests(tc.input, "default", fcs.Discovery())
 
 			if err != nil {
 				t.Fatalf("Expected to successfully parse manifests: %v", err)
@@ -45,15 +60,15 @@ func TestFixNamespace(t *testing.T) {
 		expected string                 // kinds of objects
 	}{
 		{"present",
-			map[string]interface{}{"metadata": map[string]interface{}{"namespace": "some-namespace"}},
+			map[string]interface{}{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]interface{}{"namespace": "some-namespace"}},
 			"some-namespace",
 		},
 		{"missing",
-			map[string]interface{}{"metadata": map[string]interface{}{}},
+			map[string]interface{}{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]interface{}{}},
 			"default-namespace",
 		},
 		{"nil",
-			map[string]interface{}{"metadata": map[string]interface{}{"namespace": nil}},
+			map[string]interface{}{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]interface{}{"namespace": nil}},
 			"default-namespace",
 		},
 	}
@@ -61,7 +76,9 @@ func TestFixNamespace(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			fixNamespace(&tc.input, tc.expected)
+			fcs := fake.NewSimpleClientset()
+			fcs.Resources = []*metav1.APIResourceList{FAKE_API_RESOURCES}
+			fixNamespace(&unstructured.Unstructured{tc.input}, tc.expected, fcs.Discovery())
 
 			meta, ok := tc.input["metadata"]
 			if !ok {
@@ -82,6 +99,32 @@ func TestFixNamespace(t *testing.T) {
 				t.Fatalf("Expected namespace to be: %s, instead got: %s", tc.expected, actual)
 			}
 
+		})
+	}
+}
+
+func Test_isResourceNamespaced(t *testing.T) {
+	tests := []struct {
+		name string
+		gvk  string
+		want bool
+	}{
+		{"true-pod", "Pod.v1.", true},
+		{"false-namespace", "Namespace.v1.", false},
+		{"false-non-existent", "XXX.v1.", false},
+	}
+
+	fcs := fake.NewSimpleClientset()
+	fcs.Resources = []*metav1.APIResourceList{FAKE_API_RESOURCES}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gvk, _ := schema.ParseKindArg(tt.gvk)
+
+			got := isResourceNamespaced(fcs.Discovery(), *gvk)
+			if got != tt.want {
+				t.Errorf("isResourceNamespaced() got = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This uses discovery client to check if given type of resource is namespaced. Discovery client should be cached, so it's fine to call ServerResourcesForGroupVersion() multiple times.

Fixes #195