### PR TITLE
ci: Fix missing build info in docker images

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: build docker image
         run: |
-          docker buildx build .
+          docker buildx build --build-arg GITHUB_REF --build-arg GITHUB_SHA .
   integration-test:
     name: integration test
     needs:
@@ -170,6 +170,9 @@ jobs:
           context: .
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create-release.outputs.tag_name }}
+          build-args: |
+            GITHUB_REF
+            GITHUB_SHA
       - name: Push latest
         uses: docker/build-push-action@v3
         if: ${{ !contains(github.ref, 'nightly') }}


### PR DESCRIPTION
This PR should fix missing build info in Doker image binaries 🤞 

Fixes: #378