### PR TITLE
ci: Fix missing build info in docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.19.1-alpine3.16 as builder
+ARG GITHUB_REF GITHUB_SHA
 WORKDIR /src
 COPY go.mod go.sum ./
 COPY scripts scripts
@@ -7,6 +8,7 @@ RUN go mod download
 COPY cmd cmd
 COPY pkg pkg
 COPY Makefile Makefile
+RUN export
 RUN make all
 
 FROM scratch


### PR DESCRIPTION
Any Docker build arguments must be explicitly declared in the relevant section of Dockerfile [^1], otherwise, these are not visible to build inside even when passed via `--build-arg`.

Tested locally:

```shell
$ GITHUB_REF=refs/tags/xxx GITHUB_SHA=123 docker build --build-arg GITHUB_REF --build-arg GITHUB_SHA -t test ./
...
...
=> [builder 11/11] RUN make all                                                                                                                                               25.6s
 => => # mkdir -p bin
 => => # go build -ldflags="-s -w -X main.version=xxx -X main.gitSha=123" \
...
...
$ docker run -it --rm test -v                                                                                                                           0
11:03AM INF version xxx (git sha 123)
```



[^1]: https://docs.docker.com/engine/reference/builder/#arg

Fixes: #378