### PR TITLE
ci: Fix latest tag and avoid rebuild

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -169,17 +169,12 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create-release.outputs.tag_name }}
+          tags: |
+            ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, needs.create-release.outputs.tag_name) }}
+            ${{ !startsWith(github.ref, 'refs/tags/nightly') && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, 'latest') }}
           build-args: |
             GITHUB_REF
             GITHUB_SHA
-      - name: Push latest
-        uses: docker/build-push-action@v3
-        if: ${{ !contains(github.ref, 'nightly') }}
-        with:
-          context: .
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
   release-artifacts:
     name: Release Artifacts
     needs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN go mod download
 COPY cmd cmd
 COPY pkg pkg
 COPY Makefile Makefile
-RUN export
 RUN make all
 
 FROM scratch


### PR DESCRIPTION
This should, hopefully 🤞, avoid rebuilding of the docker image with a different hash (and also currently broken as it's missing the build-args).