### PR TITLE
fix: Ignore empty documents from Helm collectors

### DIFF
--- a/pkg/collector/helm.go
+++ b/pkg/collector/helm.go
@@ -23,13 +23,15 @@ func parseManifests(manifest string, defaultNamespace string, discoveryClient di
 			err = fmt.Errorf("failed to parse manifest %s: %v", i, err)
 			return nil, err
 		}
+		// the helm's SplitManifests can keep empty documents in some cases
+		if len(manifest) != 0 {
+			umanifest := &unstructured.Unstructured{Object: manifest}
+			log.Debug().Msgf("retrieved: %s/%s (%s)", umanifest.GetNamespace(), umanifest.GetName(), umanifest.GroupVersionKind())
 
-		umanifest := &unstructured.Unstructured{Object: manifest}
-		log.Debug().Msgf("retrieved: %s/%s (%s)", umanifest.GetNamespace(), umanifest.GetName(), umanifest.GroupVersionKind())
+			fixNamespace(umanifest, defaultNamespace, discoveryClient)
 
-		fixNamespace(umanifest, defaultNamespace, discoveryClient)
-
-		results = append(results, manifest)
+			results = append(results, manifest)
+		}
 	}
 
 	return results, nil

--- a/pkg/collector/helm_test.go
+++ b/pkg/collector/helm_test.go
@@ -19,7 +19,7 @@ var FAKE_API_RESOURCES = &metav1.APIResourceList{
 	},
 }
 
-func TestSplitManifests(t *testing.T) {
+func TestParseManifests(t *testing.T) {
 	testCases := []struct {
 		name     string
 		input    string // manifest
@@ -31,6 +31,14 @@ func TestSplitManifests(t *testing.T) {
 		},
 		{"multiple",
 			"abc: x\n---\ndef: y",
+			2,
+		},
+		{"empty",
+			"---\n---\n\n---\n\n\n---\n---",
+			0,
+		},
+		{"mix-with-empty",
+			"abc: x\n---\n\n---\ndef: y\n",
 			2,
 		},
 	}


### PR DESCRIPTION
Helm's SplitManifests can keep empty documents (sometimes), this results in an unnecessary warning log line and unwanted empty resources.

before:
```bash
$./bin/kubent-darwin-amd64
1:14PM INF version dev (git sha dev)
1:14PM INF Initializing collectors and retrieving data
1:14PM INF Target K8s version is 1.22.12-gke.2300
1:14PM INF Retrieved 10 resources from collector name=Cluster
1:14PM INF Retrieved 0 resources from collector name="Helm v2"
1:14PM WRN failed to discover supported resources for : groupVersion shouldn't be empty
...
```
after:
```
$./bin/kubent-darwin-amd64                                                                                                                          0
1:15PM INF >>> Kube No Trouble `kubent` <<<
1:15PM INF version dev (git sha dev)
1:15PM INF Initializing collectors and retrieving data
1:15PM INF Target K8s version is 1.22.12-gke.2300
1:15PM INF Retrieved 10 resources from collector name=Cluster
1:15PM INF Retrieved 0 resources from collector name="Helm v2"
1:15PM INF Retrieved 40 resources from collector name="Helm v3"
1:15PM INF Loaded ruleset name=custom.rego.tmpl
...
```
_I.e. notice the `WRN failed to discover supported resources...` is gone._

fixes #385