### PR TITLE
ci: Fix latest tag issue in nightly builds

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -171,7 +171,7 @@ jobs:
           push: true
           tags: |
             ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, needs.create-release.outputs.tag_name) }}
-            ${{ !startsWith(github.ref, 'refs/tags/nightly') && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, 'latest') }}
+            ${{ ( !startsWith(github.ref, 'refs/tags/nightly') && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, 'latest') ) || '' }}
           build-args: |
             GITHUB_REF
             GITHUB_SHA

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.SHELL := bash
+SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c
 .ONESHELL:
 .SECONDEXPANSION:

--- a/scripts/alpine-setup.sh
+++ b/scripts/alpine-setup.sh
@@ -8,6 +8,7 @@ OPA_VERSION="0.22.0"
 CHANGELOG_VERSION="1.1.0"
 
 apk add --update --no-cache \
+	bash \
 	curl \
 	git \
 	jq \


### PR DESCRIPTION
Another try to fix broken tags on docker building GH actions.

Currently nightly builds are broken, as the `${{ !startsWith(github.ref, 'refs/tags/nightly') && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, 'latest') }}` evaluates to `false`. After this change, it will evaluate to an empty string.

_Warning: not 100% sure this will work - while the syntax will return an empty string, I'm not 100% sure if the `docker/build-push-action@v3` action will deal with that. If this won't work, we can try the metadata action[^1], but that seems pretty complex too._

[^1]: https://github.com/docker/metadata-action 