### PR TITLE
feat: Disable any logging from go-client's klog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,12 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/go-version v1.3.0
 	github.com/open-policy-agent/opa v0.46.1
-	github.com/rs/zerolog v1.21.1-0.20210413053206-582f0cf0e39b
+	github.com/rs/zerolog v1.26.1
 	github.com/spf13/pflag v1.0.5
 	helm.sh/helm/v3 v3.10.2
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.4
+	k8s.io/klog/v2 v2.70.1
 )
 
 require (
@@ -77,7 +78,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.25.4 // indirect
 	k8s.io/apiextensions-apiserver v0.25.2 // indirect
-	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,7 +104,6 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -393,9 +392,9 @@ github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqn
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
-github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
-github.com/rs/zerolog v1.21.1-0.20210413053206-582f0cf0e39b h1:lZjlZ6/ExLhIqPOmlh0dVJnBbiKokcjffr022PlkSSo=
-github.com/rs/zerolog v1.21.1-0.20210413053206-582f0cf0e39b/go.mod h1:ZPhntP/xmq1nnND05hhpAh2QMhSsA4UN3MGZ6O2J3hM=
+github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=
+github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
 github.com/rubenv/sql-migrate v1.1.2 h1:9M6oj4e//owVVHYrFISmY9LBRw6gzkCNmD9MV36tZeQ=
 github.com/rubenv/sql-migrate v1.1.2/go.mod h1:/7TZymwxN8VWumcIxw1jjHEcR1djpdkMHQPT4FWdnbQ=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -470,6 +469,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/collector/kube.go
+++ b/pkg/collector/kube.go
@@ -38,6 +38,7 @@ func newClientRestConfig(kubeconfig string, kubecontext string, inClusterFn func
 	if kubeconfig == "" {
 		if restConfig, err := inClusterFn(); err == nil {
 			restConfig.UserAgent = userAgent
+			restConfig.WarningHandler = rest.NoWarnings{}
 			return restConfig, nil
 		}
 	}
@@ -64,6 +65,7 @@ func newClientRestConfig(kubeconfig string, kubecontext string, inClusterFn func
 	}
 
 	restConfig.UserAgent = userAgent
+	restConfig.WarningHandler = rest.NoWarnings{}
 	return restConfig, nil
 }
 

--- a/pkg/collector/kube_test.go
+++ b/pkg/collector/kube_test.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"k8s.io/client-go/rest"
@@ -141,6 +142,14 @@ func TestNewClientRestConfigWithContext(t *testing.T) {
 	if config.Host != expectedHost {
 		t.Fatalf("Expected host from context %s to be: %s, got %s instead", expectedContext, expectedHost, config.Host)
 	}
+
+	if config.UserAgent != USER_AGENT {
+		t.Fatalf("Expected %s UserAgent, instead got: %s", USER_AGENT, config.UserAgent)
+	}
+
+	if _, ok := config.WarningHandler.(rest.NoWarnings); !ok {
+		t.Fatalf("Expected NoWarnings warnings handler, instead got: %s", reflect.TypeOf(config.WarningHandler).Name())
+	}
 }
 
 func TestNewClientRestConfigContextMissing(t *testing.T) {
@@ -164,6 +173,12 @@ func TestNewClientRestConfigInCluster(t *testing.T) {
 	}
 	if cfg.Host != expectedHost {
 		t.Fatalf("Expected %s host, instead got: %s", expectedHost, cfg.Host)
+	}
+	if cfg.UserAgent != USER_AGENT {
+		t.Fatalf("Expected %s UserAgent, instead got: %s", USER_AGENT, cfg.UserAgent)
+	}
+	if _, ok := cfg.WarningHandler.(rest.NoWarnings); !ok {
+		t.Fatalf("Expected NoWarnings warnings handler, instead got: %s", reflect.TypeOf(cfg.WarningHandler).Name())
 	}
 }
 


### PR DESCRIPTION
This PR disables warnings from K8S go-client. Unfortunately, this is not sufficient to also suppress the warning about deprecated auth plugins, therefore the need for klog output code too.

But in general any direct logging from 3rd-party libs is undesirable, and this configures K8S's go-client klog to discard any logs.

I've added some tests to cover some unexpected 3rd-party output, but asthis depends on the environment and kubeconfig config, incl. providers, and is not easily reproducible, this should be covered by an integration test, as the current test does not fully cover this. Opened #406.

fixes #402


Compare output from #402 (pre) with the following (post) - the warnings from klog are gone:
```shell
$ ./bin/kubent-darwin-amd64
11:35AM INF >>> Kube No Trouble `kubent` <<<
11:35AM INF version dev (git sha dev)
11:35AM INF Initializing collectors and retrieving data
11:35AM INF Target K8s version is 1.23.8-gke.1900
11:35AM INF Retrieved 10 resources from collector name=Cluster
11:35AM INF Retrieved 40 resources from collector name="Helm v3"
11:35AM INF Loaded ruleset name=custom.rego.tmpl
11:35AM INF Loaded ruleset name=deprecated-1-16.rego
11:35AM INF Loaded ruleset name=deprecated-1-22.rego
11:35AM INF Loaded ruleset name=deprecated-1-25.rego
11:35AM INF Loaded ruleset name=deprecated-1-26.rego
11:35AM INF Loaded ruleset name=deprecated-future.rego
```

_The usual SonarCloud's warning is about some dupe code in tests - not a newly added code, and in tests._