### PR TITLE
chore: Codespell should ignore go.sum

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = go.sum


### PR DESCRIPTION
Codespell wrongly flags `go.sum` [^1]. This PR should make it ignore the file.

[^1]: https://github.com/doitintl/kube-no-trouble/actions/runs/4233400288/jobs/7354317644