### PR TITLE
Add missing buildx setup action for image build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -177,6 +177,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
I noticed that [latest build failed](https://github.com/doitintl/kube-no-trouble/actions/runs/4258761344/jobs/7410371441) to push docker images because docker buildx was not set up properly