### PR TITLE
fix: Move autoscaling/v2beta1 removed to Kubernetes 1.25

### DIFF
--- a/pkg/rules/rego/deprecated-1-25.rego
+++ b/pkg/rules/rego/deprecated-1-25.rego
@@ -46,6 +46,11 @@ deprecated_api(kind, api_version) = api {
 			"new": "batch/v1",
 			"since": "1.21",
 		},
+		"HorizontalPodAutoscaler": {
+			"old": ["autoscaling/v2beta1"],
+			"new": "autoscaling/v2",
+			"since": "1.23",
+		},
 	}
 
 	deprecated_apis[kind].old[_] == api_version

--- a/pkg/rules/rego/deprecated-1-26.rego
+++ b/pkg/rules/rego/deprecated-1-26.rego
@@ -21,7 +21,7 @@ deprecated_resource(r) = api {
 
 deprecated_api(kind, api_version) = api {
 	deprecated_apis = {"HorizontalPodAutoscaler": {
-		"old": ["autoscaling/v2beta1", "autoscaling/v2beta2"],
+		"old": ["autoscaling/v2beta2"],
 		"new": "autoscaling/v2",
 		"since": "1.23",
 	}}

--- a/test/rules_125_test.go
+++ b/test/rules_125_test.go
@@ -6,6 +6,7 @@ import (
 
 func TestRego125(t *testing.T) {
 	testCases := []resourceFixtureTestCase{
+		{"AutoScaler", []string{"../fixtures/autoscaler-v2beta1.yaml"}, []string{"HorizontalPodAutoscaler"}},
 		{"CronJob", []string{"../fixtures/cronjob-v1beta1.yaml"}, []string{"CronJob"}},
 		{"EndpointSlice", []string{"../fixtures/endpointslice-v1beta1.yaml"}, []string{"EndpointSlice"}},
 		{"PodDisruptionBudget", []string{"../fixtures/poddisruptionbudget-v1beta1.yaml"}, []string{"PodDisruptionBudget"}},

--- a/test/rules_126_test.go
+++ b/test/rules_126_test.go
@@ -6,8 +6,7 @@ import (
 
 func TestRego126(t *testing.T) {
 	testCases := []resourceFixtureTestCase{
-		{"AutoScaler-v2beta1", []string{"../fixtures/autoscaler-v2beta1.yaml"}, []string{"HorizontalPodAutoscaler"}},
-		{"AutoScaler-v2beta2", []string{"../fixtures/autoscaler-v2beta2.yaml"}, []string{"HorizontalPodAutoscaler"}},
+		{"AutoScaler", []string{"../fixtures/autoscaler-v2beta2.yaml"}, []string{"HorizontalPodAutoscaler"}},
 	}
 
 	testResourcesUsingFixtures(t, testCases)


### PR DESCRIPTION
Fixes #459 
