### PR TITLE
feat: Added deprecations for kubernetes 1.26, 1.27, 1.29

### DIFF
--- a/pkg/rules/rego/deprecated-1-27.rego
+++ b/pkg/rules/rego/deprecated-1-27.rego
@@ -10,7 +10,7 @@ main[return] {
 		"Kind": resource.kind,
 		"ApiVersion": api.old,
 		"ReplaceWith": api.new,
-		"RuleSet": "Deprecated APIs removed in 1.26",
+		"RuleSet": "Deprecated APIs removed in 1.27",
 		"Since": api.since,
 	}
 }

--- a/pkg/rules/rego/deprecated-1-27.rego
+++ b/pkg/rules/rego/deprecated-1-27.rego
@@ -1,4 +1,4 @@
-package deprecated126
+package deprecated127
 
 main[return] {
 	resource := input[_]
@@ -20,23 +20,11 @@ deprecated_resource(r) = api {
 }
 
 deprecated_api(kind, api_version) = api {
-	deprecated_apis = {
-		"HorizontalPodAutoscaler": {
-			"old": ["autoscaling/v2beta1", "autoscaling/v2beta2"],
-			"new": "autoscaling/v2",
-			"since": "1.23",
-		},
-		"FlowSchema": {
-			"old": ["flowcontrol.apiserver.k8s.io/v1beta1"],
-			"new": "flowcontrol.apiserver.k8s.io/v1beta3",
-			"since": "1.26",
-		},
-		"PriorityLevelConfiguration": {
-			"old": ["flowcontrol.apiserver.k8s.io/v1beta1"],
-			"new": "flowcontrol.apiserver.k8s.io/v1beta3",
-			"since": "1.26",
-		},
-	}
+	deprecated_apis = {"CSIStorageCapacity": {
+		"old": ["storage.k8s.io/v1beta1"],
+		"new": "storage.k8s.io/v1",
+		"since": "1.24",
+	}}
 
 	deprecated_apis[kind].old[_] == api_version
 

--- a/pkg/rules/rego/deprecated-1-29.rego
+++ b/pkg/rules/rego/deprecated-1-29.rego
@@ -10,7 +10,7 @@ main[return] {
 		"Kind": resource.kind,
 		"ApiVersion": api.old,
 		"ReplaceWith": api.new,
-		"RuleSet": "Deprecated APIs removed in 1.26",
+		"RuleSet": "Deprecated APIs removed in 1.29",
 		"Since": api.since,
 	}
 }

--- a/pkg/rules/rego/deprecated-1-29.rego
+++ b/pkg/rules/rego/deprecated-1-29.rego
@@ -1,4 +1,4 @@
-package deprecated126
+package deprecated129
 
 main[return] {
 	resource := input[_]
@@ -21,18 +21,13 @@ deprecated_resource(r) = api {
 
 deprecated_api(kind, api_version) = api {
 	deprecated_apis = {
-		"HorizontalPodAutoscaler": {
-			"old": ["autoscaling/v2beta1", "autoscaling/v2beta2"],
-			"new": "autoscaling/v2",
-			"since": "1.23",
-		},
 		"FlowSchema": {
-			"old": ["flowcontrol.apiserver.k8s.io/v1beta1"],
+			"old": ["flowcontrol.apiserver.k8s.io/v1beta2"],
 			"new": "flowcontrol.apiserver.k8s.io/v1beta3",
 			"since": "1.26",
 		},
 		"PriorityLevelConfiguration": {
-			"old": ["flowcontrol.apiserver.k8s.io/v1beta1"],
+			"old": ["flowcontrol.apiserver.k8s.io/v1beta2"],
 			"new": "flowcontrol.apiserver.k8s.io/v1beta3",
 			"since": "1.26",
 		},


### PR DESCRIPTION
- Added `FlowControlResources` deprecations for kubernetes [1.26](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v126)
- Added deprecations for kubernetes [1.27](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-27)
- Added deprecations for kubernetes [1.29](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-29)