### PR TITLE
Scoop install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Or download the
 [latest release](https://github.com/doitintl/kube-no-trouble/releases/latest)
 for your platform and unpack manually.
 
+### Install on Windows with [Scoop](https://scoop.sh)
+
+```powershell
+scoop install kubent
+```
+
 
 ## Usage
 


### PR DESCRIPTION
https://github.com/ScoopInstaller/Main/pull/4454 has implemented the support for [Scoop](https://scoop.sh). 

Behind the scenes it does the same thing as the install instructions specify (i.e., go to releases and download) plus it adds auto-update too.