### PR TITLE
fix the fixNamespace function

### DIFF
--- a/pkg/collector/helm.go
+++ b/pkg/collector/helm.go
@@ -39,7 +39,7 @@ func parseManifests(manifest string, defaultNamespace string, discoveryClient di
 
 func fixNamespace(resource *unstructured.Unstructured, defaultNamespace string, discoveryClient discovery.DiscoveryInterface) {
 	// Default to the release namespace if the manifest doesn't have the namespace set
-	if resource.GetNamespace() == "" && isResourceNamespaced(discoveryClient, resource.GroupVersionKind()) {
+	if resource.GetNamespace() == "" && !isResourceNamespaced(discoveryClient, resource.GroupVersionKind()) {
 		resource.SetNamespace(defaultNamespace)
 	}
 }


### PR DESCRIPTION
For deprecated resources with no namespace the cmd throws

"
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/doitintl/kube-no-trouble/pkg/judge.(*RegoJudge).Eval(0x14000ba8350, {0x1400c258000, 0x394, 0x400})
	/__w/kube-no-trouble/kube-no-trouble/pkg/judge/rego.go:61 +0x684
main.main()
	/__w/kube-no-trouble/kube-no-trouble/cmd/kubent/main.go:146 +0x564
"

That's because the condition in fixNamespaces needs to be reverted to match non-namespaced resources.