### PR TITLE
feat: add 1.26 1.27 1.29 deprecations

### DIFF
--- a/fixtures/csistoragecapacity-v1beta1.yaml
+++ b/fixtures/csistoragecapacity-v1beta1.yaml
@@ -1,0 +1,5 @@
+kind: CSIStorageCapacity
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: my-csi-capacity
+storageClassName: gp2

--- a/fixtures/flowschema-v1beta1.yaml
+++ b/fixtures/flowschema-v1beta1.yaml
@@ -1,0 +1,30 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta1
+kind: FlowSchema
+metadata:
+  name: service-accounts-test
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 9000
+  priorityLevelConfiguration:
+    name: workload-medium
+  rules:
+  - nonResourceRules:
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - '*'
+    resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - group:
+        name: system:serviceaccounts
+      kind: Group

--- a/fixtures/flowschema-v1beta2.yaml
+++ b/fixtures/flowschema-v1beta2.yaml
@@ -1,0 +1,30 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+kind: FlowSchema
+metadata:
+  name: service-accounts-test
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 9000
+  priorityLevelConfiguration:
+    name: workload-medium
+  rules:
+  - nonResourceRules:
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - '*'
+    resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - group:
+        name: system:serviceaccounts
+      kind: Group

--- a/fixtures/prioritylevelconfiguration-v1beta1.yaml
+++ b/fixtures/prioritylevelconfiguration-v1beta1.yaml
@@ -1,0 +1,14 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta1
+kind: PriorityLevelConfiguration
+metadata:
+  name: workload-medium
+spec:
+  limited:
+    assuredConcurrencyShares: 70
+    limitResponse:
+      queuing:
+        handSize: 6
+        queueLengthLimit: 50
+        queues: 128
+      type: Queue
+  type: Limited

--- a/fixtures/prioritylevelconfiguration-v1beta2.yaml
+++ b/fixtures/prioritylevelconfiguration-v1beta2.yaml
@@ -1,0 +1,14 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+kind: PriorityLevelConfiguration
+metadata:
+  name: workload-medium
+spec:
+  limited:
+    assuredConcurrencyShares: 70
+    limitResponse:
+      queuing:
+        handSize: 6
+        queueLengthLimit: 50
+        queues: 128
+      type: Queue
+  type: Limited

--- a/pkg/collector/cluster.go
+++ b/pkg/collector/cluster.go
@@ -83,6 +83,7 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csinodes"},
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"},
 		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "volumeattachments"},
+		schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csistoragecapacities"},
 		schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"},
 		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"},
 		schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"},
@@ -107,6 +108,10 @@ func (c *ClusterCollector) Get() ([]map[string]interface{}, error) {
 		schema.GroupVersionResource{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshots"},
 		schema.GroupVersionResource{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshotclasses"},
 		schema.GroupVersionResource{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshotcontents"},
+		schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Resource: "flowschemas"},
+		schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Resource: "prioritylevelconfigurations"},
+		schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "flowschemas"},
+		schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "prioritylevelconfigurations"},
 	}
 	gvrs = append(gvrs, c.additionalResources...)
 

--- a/pkg/rules/rego/deprecated-1-27.rego
+++ b/pkg/rules/rego/deprecated-1-27.rego
@@ -1,4 +1,4 @@
-package deprecated126
+package deprecated127
 
 main[return] {
 	resource := input[_]
@@ -10,7 +10,7 @@ main[return] {
 		"Kind": resource.kind,
 		"ApiVersion": api.old,
 		"ReplaceWith": api.new,
-		"RuleSet": "Deprecated APIs removed in 1.26",
+		"RuleSet": "Deprecated APIs removed in 1.27",
 		"Since": api.since,
 	}
 }
@@ -20,23 +20,11 @@ deprecated_resource(r) = api {
 }
 
 deprecated_api(kind, api_version) = api {
-	deprecated_apis = {
-		"HorizontalPodAutoscaler": {
-			"old": ["autoscaling/v2beta2"],
-			"new": "autoscaling/v2",
-			"since": "1.23",
-		},
-		"FlowSchema": {
-			"old": ["flowcontrol.apiserver.k8s.io/v1beta1"],
-			"new": "flowcontrol.apiserver.k8s.io/v1beta3",
-			"since": "1.26",
-		},
-		"PriorityLevelConfiguration": {
-			"old": ["flowcontrol.apiserver.k8s.io/v1beta1"],
-			"new": "flowcontrol.apiserver.k8s.io/v1beta3",
-			"since": "1.26",
-		},
-	}
+	deprecated_apis = {"CSIStorageCapacity": {
+		"old": ["storage.k8s.io/v1beta1"],
+		"new": "storage.k8s.io/v1",
+		"since": "1.24",
+	}}
 
 	deprecated_apis[kind].old[_] == api_version
 

--- a/pkg/rules/rego/deprecated-1-29.rego
+++ b/pkg/rules/rego/deprecated-1-29.rego
@@ -1,4 +1,4 @@
-package deprecated126
+package deprecated129
 
 main[return] {
 	resource := input[_]
@@ -10,7 +10,7 @@ main[return] {
 		"Kind": resource.kind,
 		"ApiVersion": api.old,
 		"ReplaceWith": api.new,
-		"RuleSet": "Deprecated APIs removed in 1.26",
+		"RuleSet": "Deprecated APIs removed in 1.29",
 		"Since": api.since,
 	}
 }
@@ -21,18 +21,13 @@ deprecated_resource(r) = api {
 
 deprecated_api(kind, api_version) = api {
 	deprecated_apis = {
-		"HorizontalPodAutoscaler": {
-			"old": ["autoscaling/v2beta2"],
-			"new": "autoscaling/v2",
-			"since": "1.23",
-		},
 		"FlowSchema": {
-			"old": ["flowcontrol.apiserver.k8s.io/v1beta1"],
+			"old": ["flowcontrol.apiserver.k8s.io/v1beta2"],
 			"new": "flowcontrol.apiserver.k8s.io/v1beta3",
 			"since": "1.26",
 		},
 		"PriorityLevelConfiguration": {
-			"old": ["flowcontrol.apiserver.k8s.io/v1beta1"],
+			"old": ["flowcontrol.apiserver.k8s.io/v1beta2"],
 			"new": "flowcontrol.apiserver.k8s.io/v1beta3",
 			"since": "1.26",
 		},

--- a/test/rules_126_test.go
+++ b/test/rules_126_test.go
@@ -7,6 +7,8 @@ import (
 func TestRego126(t *testing.T) {
 	testCases := []resourceFixtureTestCase{
 		{"AutoScaler", []string{"../fixtures/autoscaler-v2beta2.yaml"}, []string{"HorizontalPodAutoscaler"}},
+		{"FlowSchema", []string{"../fixtures/flowschema-v1beta1.yaml"}, []string{"FlowSchema"}},
+		{"PriorityLevelConfiguration", []string{"../fixtures/prioritylevelconfiguration-v1beta1.yaml"}, []string{"PriorityLevelConfiguration"}},
 	}
 
 	testResourcesUsingFixtures(t, testCases)

--- a/test/rules_127_test.go
+++ b/test/rules_127_test.go
@@ -1,0 +1,13 @@
+package test
+
+import (
+	"testing"
+)
+
+func TestRego127(t *testing.T) {
+	testCases := []resourceFixtureTestCase{
+		{"CSIStorageCapacity", []string{"../fixtures/csistoragecapacity-v1beta1.yaml"}, []string{"CSIStorageCapacity"}},
+	}
+
+	testResourcesUsingFixtures(t, testCases)
+}

--- a/test/rules_129_test.go
+++ b/test/rules_129_test.go
@@ -1,0 +1,14 @@
+package test
+
+import (
+	"testing"
+)
+
+func TestRego129(t *testing.T) {
+	testCases := []resourceFixtureTestCase{
+		{"FlowSchema", []string{"../fixtures/flowschema-v1beta2.yaml"}, []string{"FlowSchema"}},
+		{"PriorityLevelConfiguration", []string{"../fixtures/prioritylevelconfiguration-v1beta2.yaml"}, []string{"PriorityLevelConfiguration"}},
+	}
+
+	testResourcesUsingFixtures(t, testCases)
+}


### PR DESCRIPTION
## WHAT

This PR is adding the following deprecations.

- [v1.26](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26) `flowcontrol` 
- [v1.27](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-27) `CSIStorageCapacity`
- [v1.29](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-29) `flowcontrol`

## Example

This has been tested with the resources included inside fixtures in a k8s v1.24 running cluster. Here is the output:
```
❯ ./bin/kubent -t 1.26
1:08PM INF >>> Kube No Trouble `kubent` <<<
1:08PM INF version dev (git sha dev)
1:08PM INF Initializing collectors and retrieving data
1:08PM INF Target K8s version is 1.26.0
1:08PM INF Retrieved 198 resources from collector name=Cluster
1:08PM INF Retrieved 7 resources from collector name="Helm v3"
1:08PM INF Loaded ruleset name=custom.rego.tmpl
1:08PM INF Loaded ruleset name=deprecated-1-16.rego
1:08PM INF Loaded ruleset name=deprecated-1-22.rego
1:08PM INF Loaded ruleset name=deprecated-1-25.rego
1:08PM INF Loaded ruleset name=deprecated-1-26.rego
1:08PM INF Loaded ruleset name=deprecated-1-27.rego
1:08PM INF Loaded ruleset name=deprecated-1-29.rego
1:08PM INF Loaded ruleset name=deprecated-future.rego
__________________________________________________________________________________________
>>> Deprecated APIs removed in 1.26 <<<
------------------------------------------------------------------------------------------
KIND                         NAMESPACE     NAME                    API_VERSION                            REPLACE_WITH (SINCE)
FlowSchema                   <undefined>   service-accounts-test   flowcontrol.apiserver.k8s.io/v1beta1   flowcontrol.apiserver.k8s.io/v1beta3 (1.26.0)
PriorityLevelConfiguration   <undefined>   workload-medium         flowcontrol.apiserver.k8s.io/v1beta1   flowcontrol.apiserver.k8s.io/v1beta3 (1.26.0)
__________________________________________________________________________________________
>>> Deprecated APIs removed in 1.27 <<<
------------------------------------------------------------------------------------------
KIND                 NAMESPACE   NAME              API_VERSION              REPLACE_WITH (SINCE)
CSIStorageCapacity   default     my-csi-capacity   storage.k8s.io/v1beta1   storage.k8s.io/v1 (1.24.0)
```

#### NOTE. There is [an existing open PR](https://github.com/doitintl/kube-no-trouble/pull/472) with this purpose, but it has been stalled for 60 days.