### PR TITLE
fix: Properly represent multiple versions of the same custom resource

### DIFF
--- a/pkg/rules/rego/custom.rego.tmpl
+++ b/pkg/rules/rego/custom.rego.tmpl
@@ -22,9 +22,9 @@ deprecated_resource(r) = api {
 
 deprecated_api(kind, api_version) = api {
 	deprecated_apis = {
-{{- range . }}
-		"{{ .Kind }}": {
-			"old": ["{{ .Group }}/{{ .Version }}"],
+{{- range $key, $value := . }}
+		"{{ $key }}": {
+			"old": [{{range $value}}"{{.}}",{{end}}],
 		},
 {{- end }}
 	}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -22,6 +22,7 @@ type Rule struct {
 }
 
 func FetchRegoRules(additionalResources []schema.GroupVersionKind) ([]Rule, error) {
+
 	fis, err := local.ReadDir(RULES_DIR)
 	if err != nil {
 		return nil, err
@@ -63,7 +64,17 @@ func renderRule(inputData []byte, fileName string, additionalKinds []schema.Grou
 		}
 
 		var tpl bytes.Buffer
-		if err := t.Execute(&tpl, additionalKinds); err != nil {
+		customEntries := make(map[string][]string)
+		for _, gvk := range additionalKinds {
+			kind := gvk.Kind
+			if customEntries[kind] == nil {
+				customEntries[kind] = []string{fmt.Sprintf("%s/%s", gvk.Group, gvk.Version)}
+			} else {
+				customEntries[kind] = append(customEntries[kind], fmt.Sprintf("%s/%s", gvk.Group, gvk.Version))
+			}
+		}
+
+		if err := t.Execute(&tpl, customEntries); err != nil {
 			return nil, fmt.Errorf("failed to render template %s: %w", fileName, err)
 		}
 

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -19,6 +19,9 @@ func TestFetchRules(t *testing.T) {
 		}
 		return nil
 	})
+	if err != nil {
+		t.Errorf("Failed to filenames with: %s", err)
+	}
 
 	rules, err := FetchRegoRules([]schema.GroupVersionKind{})
 	if err != nil {
@@ -39,14 +42,8 @@ func TestFetchRulesWithAdditionalResources(t *testing.T) {
 		}
 		return nil
 	})
-
-	additionalKindsStr := []string{
-		"ManagedCertificate.v1.networking.gke.io",
-		"Fake.v1beta.example.com"}
-	var additionalKinds []schema.GroupVersionKind
-	for _, ar := range additionalKindsStr {
-		gvr, _ := schema.ParseKindArg(ar)
-		additionalKinds = append(additionalKinds, *gvr)
+	if err != nil {
+		t.Errorf("Failed to filenames with: %s", err)
 	}
 
 	rules, err := FetchRegoRules([]schema.GroupVersionKind{})
@@ -69,14 +66,14 @@ func TestRenderRuleRego(t *testing.T) {
 		t.Errorf("Failed to render rule %s: %s", fileName, err)
 	}
 
-	if bytes.Compare(inputData, outputData) != 0 {
+	if !bytes.Equal(inputData, outputData) {
 		t.Errorf("expected the input to be same as output")
 	}
 }
 
 func TestRenderRuleTmpl(t *testing.T) {
 	additionalResources := []schema.GroupVersionKind{
-		schema.GroupVersionKind{
+		{
 			Group:   "example.com",
 			Version: "v2",
 			Kind:    "Test",
@@ -93,7 +90,7 @@ func TestRenderRuleTmpl(t *testing.T) {
 		t.Errorf("failed to render rule %s: %s", fileName, err)
 	}
 
-	if bytes.Compare(expectedData, outputData) != 0 {
+	if !bytes.Equal(expectedData, outputData) {
 		t.Errorf("result does not match expected output, expected: %s, got: %s", expectedData, outputData)
 	}
 }
@@ -112,17 +109,17 @@ func TestRenderRuleTmplFail(t *testing.T) {
 
 func TestRenderMultipleResources(t *testing.T) {
 	additionalResources := []schema.GroupVersionKind{
-		schema.GroupVersionKind{
+		{
 			Group:   "example.com",
 			Version: "v2",
 			Kind:    "Test",
 		},
-		schema.GroupVersionKind{
+		{
 			Group:   "example.com",
 			Version: "v3",
 			Kind:    "Test",
 		},
-		schema.GroupVersionKind{
+		{
 			Group:   "example.com",
 			Version: "v2",
 			Kind:    "Result",
@@ -141,7 +138,7 @@ func TestRenderMultipleResources(t *testing.T) {
 
 	outputData = []byte(strings.TrimSpace(string(outputData)))
 
-	if bytes.Compare(expectedData, outputData) != 0 {
+	if !bytes.Equal(expectedData, outputData) {
 		t.Errorf("result does not match expected output, expected: %s, got: %s", expectedData, outputData)
 	}
 }


### PR DESCRIPTION
I took a quick peek into the issue #515 that I opened earlier. Looks like it was an issue with how the Rego template was being rendered for additional custom resources. Simply combined the resource versions in the go code before passing it all off to the template.

If this approach is deemed ok, I will go back and write up some additional testing around this.