### PR TITLE
feat: Add prometheus printer

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -8,9 +8,10 @@ import (
 )
 
 var printers = map[string]func(string) (Printer, error){
-	"json": newJSONPrinter,
-	"text": newTextPrinter,
-	"csv":  newCSVPrinter,
+	"json":       newJSONPrinter,
+	"text":       newTextPrinter,
+	"csv":        newCSVPrinter,
+	"prometheus": newPrometheusPrinter,
 }
 
 type Printer interface {

--- a/pkg/printer/prometheus.go
+++ b/pkg/printer/prometheus.go
@@ -1,20 +1,52 @@
 package printer
 
 import (
+	"errors"
+	"os"
+
 	"github.com/doitintl/kube-no-trouble/pkg/judge"
+	prom "github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus/client_golang/prometheus/push"
 )
 
 type PrometheusPrinter struct {
+	gauge  *prom.GaugeVec
+	pusher *push.Pusher
+	job    string
 }
 
 func newPrometheusPrinter(outputFileName string) (Printer, error) {
-	return &PrometheusPrinter{}, nil
+	gatewayUrl := os.Getenv("PUSHGATEWAY_URL")
+	job := os.Getenv("PUSHGATEWAY_JOB")
+
+	if gatewayUrl == "" || job == "" {
+		return &PrometheusPrinter{}, errors.New("pushgateway URL or job not defined")
+	}
+
+	gauge := prom.NewGaugeVec(prom.GaugeOpts{
+		Name: "kubent_deprecated_objects",
+		Help: "Objects which have been detected by kubent as being pinned to deprecated APIs",
+	}, []string{"name", "namespace", "kind", "api_version", "rule_set", "replace_with", "since"})
+	pusher := push.New(gatewayUrl, job).Collector(gauge)
+
+	return &PrometheusPrinter{
+		gauge,
+		pusher,
+		job,
+	}, nil
 }
 
-func (p *PrometheusPrinter) Print([]judge.Result) error {
+func (p *PrometheusPrinter) Print(results []judge.Result) error {
+	p.gauge.Reset()
+
+	for _, r := range results {
+		p.gauge.WithLabelValues(r.Name, r.Namespace, r.Kind, r.ApiVersion, r.RuleSet, r.ReplaceWith, r.Since.String()).Set(1)
+	}
+
 	return nil
 }
 
 func (p *PrometheusPrinter) Close() error {
-	return nil
+	return p.pusher.Push()
 }

--- a/pkg/printer/prometheus.go
+++ b/pkg/printer/prometheus.go
@@ -1,0 +1,20 @@
+package printer
+
+import (
+	"github.com/doitintl/kube-no-trouble/pkg/judge"
+)
+
+type PrometheusPrinter struct {
+}
+
+func newPrometheusPrinter(outputFileName string) (Printer, error) {
+	return &PrometheusPrinter{}, nil
+}
+
+func (p *PrometheusPrinter) Print([]judge.Result) error {
+	return nil
+}
+
+func (p *PrometheusPrinter) Close() error {
+	return nil
+}


### PR DESCRIPTION
Adding a new "printer" (reporter, exporter?) to push Kubent output to Prometheus via Pushgateway. Any feedback is appreciated.

Relates to #302 and the discussion in #218

## New Configuration

### Flags
* `-o prometheus` is now an allowed option

### Environment Variables
* `PUSHGATEWAY_URL`: The URL of the Prometheus Pushgateway.
* `PUSHGATEWAY_JOB`: The job to collect metrics under.

If `-o prometheus` is set, then both of these variables are required to be set.

## Remaining Questions
* Maybe need to expand on the configuration abilities for printers...Is environment variables the right approach or should printers be able to accept custom config/define their own flags?

## Remaining Work
* [ ] Add Pushgateway auth options
* [ ] Add unit testing