### PR TITLE
fix: install.sh in dumb TERM

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,6 +26,10 @@ check_binaries() {
 
 # Check if we have colors available, it looks good
 check_colors(){
+  GREEN=''
+  RED=''
+  YELLOW=''
+  NOCOL=''
   if command -v tput > /dev/null; then
     COLORS="$(tput colors)"
     if [ -n "${COLORS}" ] && [ "${COLORS}" -ge 8 ]; then
@@ -34,11 +38,6 @@ check_colors(){
       YELLOW="$(tput setaf 3)"
       NOCOL="$(tput sgr0)"
     fi
-  else
-    GREEN=''
-    RED=''
-    YELLOW=''
-    NOCOL=''
   fi
 }
 


### PR DESCRIPTION
When $TERM is dumb the number of colours returned is -1 we end up with no values set for the colours.

To test this:
```bash
export TERM=dumb
sh -c "$(curl -sSL https://git.io/install-kubent)"
```

You should get an error regarding parameter expansion:

```
sh: 96: GREEN: parameter not set
```

This PR fixes the issue by initialising the variables no matter what.