### PR TITLE
Warn and Fix Up Invalid Namespaces on Objects

### DIFF
--- a/pkg/judge/rego.go
+++ b/pkg/judge/rego.go
@@ -2,6 +2,7 @@ package judge
 
 import (
 	"context"
+
 	"github.com/doitintl/kube-no-trouble/pkg/rules"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/rs/zerolog/log"
@@ -54,6 +55,12 @@ func (j *RegoJudge) Eval(input []map[string]interface{}) ([]Result, error) {
 				since, err := NewVersion(m["Since"].(string))
 				if err != nil {
 					log.Debug().Msgf("Failed to parse version: %s", err)
+				}
+
+				// shouldn't really happen - but if it does fix up and move on
+				if m["Namespace"] == nil {
+					log.Warn().Msgf("Object has invalid namespace: %s/%s %s", m["ApiVersion"].(string), m["Kind"].(string), m["Name"].(string))
+					m["Namespace"] = "<undefined>"
 				}
 
 				results = append(results, Result{


### PR DESCRIPTION
This is to avoid issues such as https://github.com/doitintl/kube-no-trouble/issues/505. I have been seeing this error myself, which manifests as:
```
10:53AM TRC parsing +map[ApiVersion:batch/v1beta1 Kind:CronJob Name:resource123 Namespace:<nil> ReplaceWith:batch/v1 RuleSet:Deprecated APIs removed in 1.25 Since:1.21]
panic: interface conversion: interface {} is nil, not string
```

This is a simple PR which just warns the user that the object's namespace was not collected correctly and then sets it to `<undefined>`. The message could also be amended to ask the user to report the issue to the developer. I figure this is a better outcome then a panic, and it also fixes the problem I (and presumably others) was having. 