### PR TITLE
feat(resource-labels): Add labels flag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Otherwise there's `Makefile`
 ```sh
 $ make
 make
-all                            Cean, build and pack
+all                            Clean, build and pack
 help                           Prints list of tasks
 build                          Build binary
 generate                       Go generate

--- a/fixtures/deployment-v1beta1-labels.yaml
+++ b/fixtures/deployment-v1beta1-labels.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: nginx-deployment-old
+  labels:
+    app: nginx
 spec:
   replicas: 3
   selector:

--- a/fixtures/expected-json-output-labels.json
+++ b/fixtures/expected-json-output-labels.json
@@ -7,6 +7,8 @@
 		"RuleSet": "Deprecated APIs removed in 1.16",
 		"ReplaceWith": "apps/v1",
 		"Since": "1.9.0",
-		"Labels": {}
+		"Labels": {
+			"app": "nginx"
+		}
 	}
 ]

--- a/pkg/collector/file_test.go
+++ b/pkg/collector/file_test.go
@@ -52,7 +52,7 @@ func TestFileCollectorGet(t *testing.T) {
 				t.Errorf("Expected to get %d, got %d", len(tc.expected), len(manifests))
 			}
 
-			for i, _ := range manifests {
+			for i := range manifests {
 				if manifests[i]["kind"] != tc.expected[i] {
 					t.Errorf("Expected to get %s, instead got: %s", tc.expected[i], manifests[i]["kind"])
 				}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,9 +1,11 @@
 package config
 
 import (
-	goversion "github.com/hashicorp/go-version"
+	"context"
 	"os"
 	"testing"
+
+	goversion "github.com/hashicorp/go-version"
 
 	"github.com/spf13/pflag"
 )
@@ -11,6 +13,7 @@ import (
 func TestValidLogLevelFromFlags(t *testing.T) {
 	oldArgs := os.Args[1]
 	defer func() { os.Args[1] = oldArgs }()
+	ctx := context.Background()
 
 	var validLevels = []string{"trace", "debug", "info", "warn", "error", "fatal", "panic", "", "disabled"}
 	for i, level := range validLevels {
@@ -18,7 +21,8 @@ func TestValidLogLevelFromFlags(t *testing.T) {
 		pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
 
 		os.Args[1] = "--log-level=" + level
-		config, err := NewFromFlags()
+
+		config, _, err := NewFromFlags(ctx)
 
 		if err != nil {
 			t.Errorf("Flags parsing failed %s", err)
@@ -44,8 +48,9 @@ func TestInvalidLogLevelFromFlags(t *testing.T) {
 func TestNewFromFlags(t *testing.T) {
 	// reset for testing
 	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+	ctx := context.Background()
 
-	config, err := NewFromFlags()
+	config, _, err := NewFromFlags(ctx)
 
 	if err != nil {
 		t.Errorf("Flags parsing failed %s", err)
@@ -72,9 +77,9 @@ func TestValidateAdditionalResources(t *testing.T) {
 
 func TestValidateAdditionalResourcesFail(t *testing.T) {
 	testCases := [][]string{
-		[]string{"abcdef"},
-		[]string{""},
-		[]string{"test.v1.com"},
+		{"abcdef"},
+		{""},
+		{"test.v1.com"},
 	}
 
 	for _, tc := range testCases {
@@ -90,6 +95,7 @@ func TestTargetVersion(t *testing.T) {
 	validVersions := []string{
 		"1.16", "1.16.3", "1.2.3",
 	}
+	ctx := context.Background()
 
 	oldArgs := os.Args[1]
 	defer func() { os.Args[1] = oldArgs }()
@@ -99,7 +105,7 @@ func TestTargetVersion(t *testing.T) {
 		pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
 
 		os.Args[1] = "--target-version=" + v
-		config, err := NewFromFlags()
+		config, _, err := NewFromFlags(ctx)
 
 		if err != nil {
 			t.Errorf("Flags parsing failed %s", err)
@@ -120,7 +126,7 @@ func TestTargetVersionInvalid(t *testing.T) {
 	invalidVersions := []string{
 		"1.blah", "nope",
 	}
-
+	ctx := context.Background()
 	oldArgs := os.Args[1]
 	defer func() { os.Args[1] = oldArgs }()
 
@@ -129,7 +135,7 @@ func TestTargetVersionInvalid(t *testing.T) {
 		pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
 
 		os.Args[1] = "--target-version=" + v
-		config, _ := NewFromFlags()
+		config, _, _ := NewFromFlags(ctx)
 
 		if config.TargetVersion != nil {
 			t.Errorf("expected --target-version flag parsing to fail for: %s", v)
@@ -141,7 +147,7 @@ func TestContext(t *testing.T) {
 	validContexts := []string{
 		"my-context",
 	}
-
+	ctx := context.Background()
 	oldArgs := os.Args[1]
 	defer func() { os.Args[1] = oldArgs }()
 
@@ -150,7 +156,7 @@ func TestContext(t *testing.T) {
 		pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
 
 		os.Args[1] = "--context=" + context
-		config, err := NewFromFlags()
+		config, _, err := NewFromFlags(ctx)
 
 		if err != nil {
 			t.Errorf("Flags parsing failed %s", err)

--- a/pkg/context/context-keys.go
+++ b/pkg/context/context-keys.go
@@ -1,0 +1,5 @@
+package context
+
+type ctxKey string
+
+const LABELS_CTX_KEY ctxKey = "labels"

--- a/pkg/judge/judge.go
+++ b/pkg/judge/judge.go
@@ -8,6 +8,7 @@ type Result struct {
 	RuleSet     string
 	ReplaceWith string
 	Since       *Version
+	Labels      map[string]interface{}
 }
 
 type Judge interface {

--- a/pkg/judge/rego.go
+++ b/pkg/judge/rego.go
@@ -63,6 +63,12 @@ func (j *RegoJudge) Eval(input []map[string]interface{}) ([]Result, error) {
 					m["Namespace"] = "<undefined>"
 				}
 
+				var labels map[string]interface{}
+				if v, ok := m["Labels"].(map[string]interface{}); ok {
+					labels = v
+				} else {
+					labels = make(map[string]interface{})
+				}
 				results = append(results, Result{
 					Name:        m["Name"].(string),
 					Namespace:   m["Namespace"].(string),
@@ -71,6 +77,7 @@ func (j *RegoJudge) Eval(input []map[string]interface{}) ([]Result, error) {
 					ReplaceWith: m["ReplaceWith"].(string),
 					RuleSet:     m["RuleSet"].(string),
 					Since:       since,
+					Labels:      labels,
 				})
 			}
 		}

--- a/pkg/judge/rego_test.go
+++ b/pkg/judge/rego_test.go
@@ -90,7 +90,7 @@ func TestEvalRules(t *testing.T) {
 				t.Errorf("expected %d findings, instead got: %d", len(tc.expected), len(results))
 			}
 
-			for i, _ := range results {
+			for i := range results {
 				if results[i].Kind != tc.expected[i] {
 					t.Errorf("expected to get %s finding, instead got: %s", tc.expected[i], results[i].Kind)
 				}

--- a/pkg/printer/csv_test.go
+++ b/pkg/printer/csv_test.go
@@ -1,11 +1,12 @@
 package printer
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
 
-	"github.com/doitintl/kube-no-trouble/pkg/judge"
+	ctxKey "github.com/doitintl/kube-no-trouble/pkg/context"
 )
 
 func TestNewCSVPrinter(t *testing.T) {
@@ -50,10 +51,12 @@ func TestCSVPrinterPrint(t *testing.T) {
 		commonPrinter: &commonPrinter{tmpFile},
 	}
 
-	version, _ := judge.NewVersion("1.2.3")
-	results := []judge.Result{{"Name", "Namespace", "Kind", "1.2.3", "Test", "4.5.6", version}}
+	labelsFlag := false
+	ctx := context.WithValue(context.Background(), ctxKey.LABELS_CTX_KEY, &labelsFlag)
 
-	if err := tp.Print(results); err != nil {
+	results := getTestResult(map[string]interface{}{"key2": "value2"})
+
+	if err := tp.Print(results, ctx); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/pkg/printer/fixtures_test.go
+++ b/pkg/printer/fixtures_test.go
@@ -1,0 +1,19 @@
+package printer
+
+import "github.com/doitintl/kube-no-trouble/pkg/judge"
+
+func getTestResult(labels map[string]interface{}) []judge.Result {
+	version, _ := judge.NewVersion("1.2.3")
+
+	res := []judge.Result{{
+		Name:        "Name",
+		Namespace:   "Namespace",
+		Kind:        "Kind",
+		ApiVersion:  "1.2.3",
+		RuleSet:     "Test",
+		ReplaceWith: "4.5.6",
+		Since:       version,
+		Labels:      labels,
+	}}
+	return res
+}

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -1,12 +1,14 @@
 package printer
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 
+	ctxKey "github.com/doitintl/kube-no-trouble/pkg/context"
 	"github.com/doitintl/kube-no-trouble/pkg/judge"
 )
 
@@ -40,7 +42,6 @@ func Test_newJSONPrinter(t *testing.T) {
 		})
 	}
 }
-
 func Test_jsonPrinter_Print(t *testing.T) {
 	tmpFile, err := ioutil.TempFile(os.TempDir(), tempFilePrefix)
 	if err != nil {
@@ -52,10 +53,12 @@ func Test_jsonPrinter_Print(t *testing.T) {
 		commonPrinter: &commonPrinter{tmpFile},
 	}
 
-	version, _ := judge.NewVersion("1.2.3")
-	results := []judge.Result{{"Name", "Namespace", "Kind", "1.2.3", "Test", "4.5.6", version}}
+	results := getTestResult(map[string]interface{}{"key2": "value2"})
 
-	if err := c.Print(results); err != nil {
+	labelsFlag := false
+	ctx := context.WithValue(context.Background(), ctxKey.LABELS_CTX_KEY, &labelsFlag)
+
+	if err := c.Print(results, ctx); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -14,7 +15,7 @@ var printers = map[string]func(string) (Printer, error){
 }
 
 type Printer interface {
-	Print([]judge.Result) error
+	Print([]judge.Result, context.Context) error
 	Close() error
 }
 

--- a/pkg/printer/printer_helper.go
+++ b/pkg/printer/printer_helper.go
@@ -1,0 +1,27 @@
+package printer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	ctxKey "github.com/doitintl/kube-no-trouble/pkg/context"
+)
+
+func mapToCommaSeparatedString(m map[string]interface{}) string {
+	var sb strings.Builder
+	for k, v := range m {
+		if sb.Len() > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(fmt.Sprintf("%s:%v", k, v))
+	}
+	return sb.String()
+}
+
+func shouldShowLabels(ctx context.Context) (*bool, error) {
+	if v := ctx.Value(ctxKey.LABELS_CTX_KEY); v != nil {
+		return ctx.Value(ctxKey.LABELS_CTX_KEY).(*bool), nil
+	}
+	return nil, fmt.Errorf("labels flag not present in the context")
+}

--- a/pkg/printer/printer_helper_test.go
+++ b/pkg/printer/printer_helper_test.go
@@ -1,0 +1,118 @@
+package printer
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	ctxKey "github.com/doitintl/kube-no-trouble/pkg/context"
+)
+
+func TestTypePrinterPrint(t *testing.T) {
+	tests := []struct {
+		name       string
+		labels     map[string]interface{}
+		withLabels bool
+	}{
+		{
+			name:       "WithLabels",
+			labels:     map[string]interface{}{"app": "version1"},
+			withLabels: true,
+		},
+		{
+			name:       "NoLabels",
+			labels:     map[string]interface{}{},
+			withLabels: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile, err := ioutil.TempFile(os.TempDir(), tempFilePrefix)
+			if err != nil {
+				t.Fatalf(tempFileCreateFailureMessage, err)
+			}
+			defer os.Remove(tmpFile.Name())
+
+			tp := &csvPrinter{
+				commonPrinter: &commonPrinter{tmpFile},
+			}
+
+			results := getTestResult(tt.labels)
+
+			ctx := context.WithValue(context.Background(), ctxKey.LABELS_CTX_KEY, &tt.withLabels)
+			if err := tp.Print(results, ctx); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			fi, _ := tmpFile.Stat()
+			if fi.Size() == 0 {
+				t.Fatalf("expected non-zero size output file: %v", err)
+			}
+		})
+	}
+}
+
+func TestMapToCommaSeparatedString(t *testing.T) {
+	tests := []struct {
+		input    map[string]interface{}
+		expected string
+	}{
+		{
+			input:    map[string]interface{}{},
+			expected: "",
+		},
+		{
+			input:    map[string]interface{}{"key1": "value1"},
+			expected: "key1:value1",
+		},
+		{
+			input:    map[string]interface{}{"key1": "value1", "key2": "value2"},
+			expected: "key1:value1, key2:value2",
+		},
+		{
+			input:    map[string]interface{}{"key1": 123, "key2": true, "key3": 45.67},
+			expected: "key1:123, key2:true, key3:45.67",
+		},
+	}
+
+	for _, test := range tests {
+		result := mapToCommaSeparatedString(test.input)
+		parsedResult := parseCSVString(result)
+		parsedExpected := parseCSVString(test.expected)
+
+		// Compare the parsed maps
+		if !compareMaps(parsedResult, parsedExpected) {
+			t.Errorf("For input %v, expected %s but got %s", test.input, test.expected, result)
+		}
+	}
+}
+
+func parseCSVString(s string) map[string]string {
+	result := make(map[string]string)
+	if s == "" {
+		return result
+	}
+
+	pairs := strings.Split(s, ", ")
+	for _, pair := range pairs {
+		kv := strings.SplitN(pair, ":", 2)
+		if len(kv) == 2 {
+			result[kv[0]] = kv[1]
+		}
+	}
+	return result
+}
+
+func compareMaps(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || v != bv {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/printer/text.go
+++ b/pkg/printer/text.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -30,7 +31,7 @@ func (c *textPrinter) Close() error {
 	return c.commonPrinter.Close()
 }
 
-func (c *textPrinter) Print(results []judge.Result) error {
+func (c *textPrinter) Print(results []judge.Result, ctx context.Context) error {
 
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].Name < results[j].Name
@@ -48,15 +49,29 @@ func (c *textPrinter) Print(results []judge.Result) error {
 	ruleSet := ""
 	w := tabwriter.NewWriter(c.commonPrinter.outputFile, 10, 0, 3, ' ', 0)
 
+	labels, err := shouldShowLabels(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get labels flag from context: %w", err)
+	}
+
 	for _, r := range results {
 		if ruleSet != r.RuleSet {
 			ruleSet = r.RuleSet
 			fmt.Fprintf(w, "%s\n", strings.Repeat("_", 90))
 			fmt.Fprintf(w, ">>> %s <<<\n", ruleSet)
 			fmt.Fprintf(w, "%s\n", strings.Repeat("-", 90))
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s (%s)\n", "KIND", "NAMESPACE", "NAME", "API_VERSION", "REPLACE_WITH", "SINCE")
+			if labels != nil && *labels {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s \t(%s) \t%s\n", "KIND", "NAMESPACE", "NAME", "API_VERSION", "REPLACE_WITH", "SINCE", "LABELS")
+			} else {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s \t(%s)\n", "KIND", "NAMESPACE", "NAME", "API_VERSION", "REPLACE_WITH", "SINCE")
+			}
+
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s (%s)\n", r.Kind, r.Namespace, r.Name, r.ApiVersion, r.ReplaceWith, r.Since)
+		if labels != nil && *labels {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s \t(%s) \t%s\n", r.Kind, r.Namespace, r.Name, r.ApiVersion, r.ReplaceWith, r.Since, mapToCommaSeparatedString(r.Labels))
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s \t(%s) \n", r.Kind, r.Namespace, r.Name, r.ApiVersion, r.ReplaceWith, r.Since)
+		}
 	}
 	w.Flush()
 	return nil

--- a/pkg/printer/text_test.go
+++ b/pkg/printer/text_test.go
@@ -1,11 +1,12 @@
 package printer
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
 
-	"github.com/doitintl/kube-no-trouble/pkg/judge"
+	ctxKey "github.com/doitintl/kube-no-trouble/pkg/context"
 )
 
 func Test_newTextPrinter(t *testing.T) {
@@ -50,10 +51,11 @@ func Test_textPrinter_Print(t *testing.T) {
 		commonPrinter: &commonPrinter{tmpFile},
 	}
 
-	version, _ := judge.NewVersion("1.2.3")
-	results := []judge.Result{{"Name", "Namespace", "Kind", "1.2.3", "Test", "4.5.6", version}}
+	results := getTestResult(map[string]interface{}{"key2": "value2"})
+	labelsFlag := false
+	ctx := context.WithValue(context.Background(), ctxKey.LABELS_CTX_KEY, &labelsFlag)
 
-	if err := tp.Print(results); err != nil {
+	if err := tp.Print(results, ctx); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/pkg/rules/rego/deprecated-1-16.rego
+++ b/pkg/rules/rego/deprecated-1-16.rego
@@ -12,6 +12,7 @@ main[return] {
 		"ReplaceWith": api.new,
 		"RuleSet": "Deprecated APIs removed in 1.16",
 		"Since": api.since,
+		"Labels": get_default(resource.metadata, "labels", "<undefined>"),
 	}
 }
 

--- a/pkg/rules/rego/deprecated-1-22.rego
+++ b/pkg/rules/rego/deprecated-1-22.rego
@@ -12,6 +12,7 @@ main[return] {
 		"ReplaceWith": api.new,
 		"RuleSet": "Deprecated APIs removed in 1.22",
 		"Since": api.since,
+		"Labels": get_default(resource.metadata, "labels", "<undefined>"),
 	}
 }
 

--- a/pkg/rules/rego/deprecated-1-25.rego
+++ b/pkg/rules/rego/deprecated-1-25.rego
@@ -12,6 +12,7 @@ main[return] {
 		"ReplaceWith": api.new,
 		"RuleSet": "Deprecated APIs removed in 1.25",
 		"Since": api.since,
+		"Labels": get_default(resource.metadata, "labels", "<undefined>"),
 	}
 }
 

--- a/pkg/rules/rego/deprecated-1-26.rego
+++ b/pkg/rules/rego/deprecated-1-26.rego
@@ -12,6 +12,7 @@ main[return] {
 		"ReplaceWith": api.new,
 		"RuleSet": "Deprecated APIs removed in 1.26",
 		"Since": api.since,
+		"Labels": get_default(resource.metadata, "labels", "<undefined>"),
 	}
 }
 

--- a/pkg/rules/rego/deprecated-1-27.rego
+++ b/pkg/rules/rego/deprecated-1-27.rego
@@ -12,6 +12,7 @@ main[return] {
 		"ReplaceWith": api.new,
 		"RuleSet": "Deprecated APIs removed in 1.27",
 		"Since": api.since,
+		"Labels": get_default(resource.metadata, "labels", "<undefined>"),
 	}
 }
 

--- a/pkg/rules/rego/deprecated-1-29.rego
+++ b/pkg/rules/rego/deprecated-1-29.rego
@@ -12,6 +12,7 @@ main[return] {
 		"ReplaceWith": api.new,
 		"RuleSet": "Deprecated APIs removed in 1.29",
 		"Since": api.since,
+		"Labels": get_default(resource.metadata, "labels", "<undefined>"),
 	}
 }
 

--- a/pkg/rules/rego/deprecated-1-32.rego
+++ b/pkg/rules/rego/deprecated-1-32.rego
@@ -12,6 +12,7 @@ main[return] {
 		"ReplaceWith": api.new,
 		"RuleSet": "Deprecated APIs removed in 1.32",
 		"Since": api.since,
+		"Labels": get_default(resource.metadata, "labels", "<undefined>"),
 	}
 }
 

--- a/pkg/rules/rego/deprecated-future.rego
+++ b/pkg/rules/rego/deprecated-future.rego
@@ -12,6 +12,7 @@ main[return] {
 		"ReplaceWith": api.new,
 		"RuleSet": "Deprecated APIs to be removed in future",
 		"Since": api.since,
+		"Labels": get_default(resource.metadata, "labels", "<undefined>"),
 	}
 }
 

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -75,7 +75,7 @@ func TestRenderRuleRego(t *testing.T) {
 
 func TestRenderRuleTmpl(t *testing.T) {
 	additionalResources := []schema.GroupVersionKind{
-		schema.GroupVersionKind{
+		{
 			Group:   "example.com",
 			Version: "v2",
 			Kind:    "Test",

--- a/test/rules_custom_test.go
+++ b/test/rules_custom_test.go
@@ -14,7 +14,7 @@ func TestRegoCustom(t *testing.T) {
 	manifestName := "../fixtures/issuer-v1alpha2.yaml"
 	expectedKind := "Issuer"
 	additionalKinds := []schema.GroupVersionKind{
-		schema.GroupVersionKind{
+		{
 			Group:   "cert-manager.io",
 			Version: "v1alpha2",
 			Kind:    "Issuer",


### PR DESCRIPTION
As part of the issue #405 and and #410 , we are adding a new flag called `--labels`. 
This flag is not active as default 
- to avoid any braking changes. 
- it might be too noise for some people as some resources contain several labels.

Setting the flag `--labels=true` will include in the output a list of labels for each resource, please check the example output below


**Example for TEXT output**

```
__________________________________________________________________________________________
>>> Deprecated APIs removed in 1.26 <<<
------------------------------------------------------------------------------------------
KIND                      NAMESPACE     NAME            API_VERSION           REPLACE_WITH      (SINCE)     LABELS
HorizontalPodAutoscaler   <undefined>   test-labels-1   autoscaling/v2beta2   autoscaling/v2    (1.23.0)    k8s-app:gcp-compute-persistent-disk-csi-driver
```

**Example for CSV output**

```
api_version,kind,namespace,name,replace_with,since,rule_set,labels
autoscaling/v2beta2,HorizontalPodAutoscaler,<undefined>,test-labels-1,autoscaling/v2,1.23.0,Deprecated APIs removed in 1.26,k8s-app:gcp-compute-persistent-disk-csi-driver
```


**Example for JSON output**

```json
[
	{
		"Name": "test-labels-1",
		"Namespace": "\u003cundefined\u003e",
		"Kind": "HorizontalPodAutoscaler",
		"ApiVersion": "autoscaling/v2beta2",
		"RuleSet": "Deprecated APIs removed in 1.26",
		"ReplaceWith": "autoscaling/v2",
		"Since": "1.23.0",
		"Labels": {
			"k8s-app": "gcp-compute-persistent-disk-csi-driver"
		}
	}
]
```