### PR TITLE
fix: Change since when new API is available

### DIFF
--- a/pkg/rules/rego/deprecated-1-32.rego
+++ b/pkg/rules/rego/deprecated-1-32.rego
@@ -24,12 +24,12 @@ deprecated_api(kind, api_version) = api {
 		"FlowSchema": {
 			"old": ["flowcontrol.apiserver.k8s.io/v1beta3"],
 			"new": "flowcontrol.apiserver.k8s.io/v1",
-			"since": "1.32",
+			"since": "1.29",
 		},
 		"PriorityLevelConfiguration": {
 			"old": ["flowcontrol.apiserver.k8s.io/v1beta3"],
 			"new": "flowcontrol.apiserver.k8s.io/v1",
-			"since": "1.32",
+			"since": "1.29",
 		},
 	}
 


### PR DESCRIPTION
flowcontrol.apiserver.k8s.io/v1 is available since v1.29 as wrote in https://kubernetes.io/docs/reference/using-api/deprecation-guide/